### PR TITLE
Fix naming for prerelease

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,6 +1,6 @@
 {
   "mode": "pre",
-  "tag": "dev",
+  "tag": "rc",
   "initialVersions": {
     "fingerprint-pro-server-api-php-sdk": "5.1.1"
   },


### PR DESCRIPTION
Composer [is not happy](https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/actions/runs/11856100888/job/33041716450) about a name like `6.0.0-dev.0`.
Name like `6.0.0-rc.0` should be better.