### PR TITLE
Update tests and documentation to use optional params as named params

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ try {
 // Search for specific events
 try {
     // Search events for given visitor id marked as suspicious and "bad" bot
-    list($model, $response) = $client->searchEvents(LIMIT, null, FPJS_VISITOR_ID, 'bad', null, null, null, null, null, true);
+    list($model, $response) = $client->searchEvents(LIMIT, visitor_id: FPJS_VISITOR_ID, bot: 'bad', suspect: true);
+    // Use pagination key to get the next page
+    // list($model, $response) = $client->searchEvents(LIMIT, pagination_key: $model->getPaginationKey(), visitor_id: FPJS_VISITOR_ID, bot: 'bad', suspect: true);
     echo "<pre>" . $response->getBody()->getContents() . "</pre>";
 } catch (Exception $e) {
     echo 'Exception when calling FingerprintApi->searchEvents: ', $e->getMessage(), PHP_EOL;

--- a/docs/Api/FingerprintApi.md
+++ b/docs/Api/FingerprintApi.md
@@ -231,7 +231,7 @@ $pagination_key = "pagination_key_example"; // string | Use `paginationKey` to g
 $before = 789; // int | ⚠️ Deprecated pagination method, please use `paginationKey` instead. Timestamp (in milliseconds since epoch) used to paginate results.
 
 try {
-    list($model, $httpResponse) = $client->getVisits($visitor_id, $request_id, $linked_id, $limit, $pagination_key, $before);
+    list($model, $httpResponse) = $client->getVisits($visitor_id, request_id: $request_id, linked_id: $linked_id, limit: $limit, pagination_key: $pagination_key, before: $before);
     echo "<pre>" . $httpResponse->getBody()->getContents() . "</pre>";
 } catch (Exception $e) {
     echo 'Exception when calling FingerprintApi->getVisits: ', $e->getMessage(), PHP_EOL;
@@ -307,7 +307,7 @@ $reverse = true; // bool | Sort events in reverse timestamp order.
 $suspect = true; // bool | Filter events previously tagged as suspicious via the [Update API](https://dev.fingerprint.com/reference/updateevent).  > Note: When using this parameter, only events with the `suspect` property explicitly set to `true` or `false` are returned. Events with undefined `suspect` property are left out of the response.
 
 try {
-    list($model, $httpResponse) = $client->searchEvents($limit, $pagination_key, $visitor_id, $bot, $ip_address, $linked_id, $start, $end, $reverse, $suspect);
+    list($model, $httpResponse) = $client->searchEvents($limit, pagination_key: $pagination_key, visitor_id: $visitor_id, bot: $bot, ip_address: $ip_address, linked_id: $linked_id, start: $start, end: $end, reverse: $reverse, suspect: $suspect);
     echo "<pre>" . $httpResponse->getBody()->getContents() . "</pre>";
 } catch (Exception $e) {
     echo 'Exception when calling FingerprintApi->searchEvents: ', $e->getMessage(), PHP_EOL;

--- a/run_checks.php
+++ b/run_checks.php
@@ -89,7 +89,7 @@ try {
     $end = new DateTime();
 
     /** @var SearchEventsResponse $result */
-    list($result, $response) = $client->searchEvents(10, null, null, null, null, null, $start->getTimestamp() * 1000, $end->getTimestamp() * 1000);
+    list($result, $response) = $client->searchEvents(10, start: $start->getTimestamp() * 1000, end: $end->getTimestamp() * 1000);
     if (!is_countable($result->getEvents()) || count($result->getEvents()) === 0) {
         throw new Exception('No events found');
     }

--- a/template/README.mustache
+++ b/template/README.mustache
@@ -135,7 +135,9 @@ try {
 // Search for specific events
 try {
     // Search events for given visitor id marked as suspicious and "bad" bot
-    list($model, $response) = $client->searchEvents(LIMIT, null, FPJS_VISITOR_ID, 'bad', null, null, null, null, null, true);
+    list($model, $response) = $client->searchEvents(LIMIT, visitor_id: FPJS_VISITOR_ID, bot: 'bad', suspect: true);
+    // Use pagination key to get the next page
+    // list($model, $response) = $client->searchEvents(LIMIT, pagination_key: $model->getPaginationKey(), visitor_id: FPJS_VISITOR_ID, bot: 'bad', suspect: true);
     echo "<pre>" . $response->getBody()->getContents() . "</pre>";
 } catch (Exception $e) {
     echo 'Exception when calling FingerprintApi->searchEvents: ', $e->getMessage(), PHP_EOL;

--- a/template/api_doc.mustache
+++ b/template/api_doc.mustache
@@ -41,7 +41,7 @@ $config
 {{/allParams}}
 
 try {
-    {{#returnType}}list($model, $httpResponse) = {{/returnType}}$client->{{{operationId}}}({{#allParams}}${{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{#returnType}}
+    {{#returnType}}list($model, $httpResponse) = {{/returnType}}$client->{{{operationId}}}({{#allParams}}{{^required}}{{paramName}}: {{/required}}${{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{#returnType}}
     echo "<pre>" . $httpResponse->getBody()->getContents() . "</pre>";{{/returnType}}
 } catch (Exception $e) {
     echo 'Exception when calling {{classname}}->{{operationId}}: ', $e->getMessage(), PHP_EOL;

--- a/test/FingerprintApiTest.php
+++ b/test/FingerprintApiTest.php
@@ -802,7 +802,7 @@ class FingerprintApiTest extends TestCase
             return $this->returnMockResponse("get_event_search_200.json");
         });
 
-        list($events) = $this->fingerprint_api->searchEvents(10, null, self::MOCK_VISITOR_ID, null, null, "linked_id", null, null, true);
+        list($events) = $this->fingerprint_api->searchEvents(10, visitor_id: self::MOCK_VISITOR_ID, linked_id: "linked_id", reverse: true);
 
         $this->assertCount(1, $events->getEvents());
         $this->assertEquals("Ibk1527CUFmcnjLwIs4A9", $events->getEvents()[0]->getProducts()->getIdentification()->getData()->getVisitorId());
@@ -831,7 +831,7 @@ class FingerprintApiTest extends TestCase
             return $this->returnMockResponse('get_event_search_200.json');
         });
 
-        list($events) = $this->fingerprint_api->searchEvents(10, 'pagination', self::MOCK_VISITOR_ID, 'good', '127.0.0.1/16', 'linked_id', $start->getTimestamp(), $end->getTimestamp(), true, true);
+        list($events) = $this->fingerprint_api->searchEvents(10, pagination_key: 'pagination', visitor_id: self::MOCK_VISITOR_ID, bot: 'good', ip_address: '127.0.0.1/16', linked_id: 'linked_id', start: $start->getTimestamp(), end: $end->getTimestamp(), reverse: true, suspect: true);
 
         $this->assertCount(1, $events->getEvents());
         $this->assertEquals('Ibk1527CUFmcnjLwIs4A9', $events->getEvents()[0]->getProducts()->getIdentification()->getData()->getVisitorId());
@@ -846,7 +846,7 @@ class FingerprintApiTest extends TestCase
         $this->expectExceptionCode(400);
 
         try {
-            $this->fingerprint_api->searchEvents(10, 'pagination', self::MOCK_VISITOR_ID, 'invalid',);
+            $this->fingerprint_api->searchEvents(10, pagination_key: 'pagination', visitor_id: self::MOCK_VISITOR_ID, bot: 'invalid');
         } catch (ApiException $e) {
             $this->assertEquals(ErrorResponse::class, get_class($e->getErrorDetails()));
             $this->assertEquals(ErrorCode::REQUEST_CANNOT_BE_PARSED, $e->getErrorDetails()->getError()->getCode());


### PR DESCRIPTION
PHP supports [named arguments](https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments) starting from v8.0.0.

Documentation and examples using optional arguments as named instead of positional will provide better DX to our customers.