### PR TITLE
ci: set Datadog team in functional workflow runs

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -9,6 +9,12 @@ on:
     - cron: '0 5 * * *'
 
 jobs:
+  set_datadog_team:
+    name: 'Set Datadog team'
+    uses: fingerprintjs/dx-team-toolkit/.github/workflows/set-datadog-team.yml@v1
+    secrets:
+      DD_API_KEY: ${{ secrets.INTEGRATIONS_DATADOG_API_KEY }}
+
   functional_tests:
     name: "Functional Tests PHP ${{ matrix.php_version }}"
     runs-on: "ubuntu-latest"
@@ -35,12 +41,3 @@ jobs:
           FP_PRIVATE_API_KEY: "${{ secrets.FP_PRIVATE_API_KEY }}"
           FP_API_HOST: "${{ secrets.FP_API_HOST }}"
 
-  report-status:
-    needs: functional_tests
-    if: always()
-    uses: fingerprintjs/dx-team-toolkit/.github/workflows/report-workflow-status.yml@v1
-    with:
-      notification_title: 'PHP SDK Tests has {status_message}'
-      job_status: ${{ needs.functional_tests.result }}
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- Adds a new job to the functional workflow to set the Datadog team using the set-datadog-team workflow from dx-team-toolkit. This will associate workflow results with the integrations team in Datadog.
- Removes the report_status job in favor of centralizing notifications with Datadog monitors.