### PR TITLE
chore: remove `SLACK_WEBHOOK_URL` from e2e-tests workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,4 +26,3 @@ jobs:
       commitSha: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.RUNNER_APP_PRIVATE_KEY }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Remove the `SLACK_WEBHOOK_URL` secret parameter for the invocation of the `run-server-sdk-e2e-tests` workflow. It is no longer required.

dx-team-toolkit PR removing the secret parameter: https://github.com/fingerprintjs/dx-team-toolkit/pull/130