### PR TITLE
Drop visitorId check and refactor functional tests

### DIFF
--- a/run_checks.php
+++ b/run_checks.php
@@ -40,11 +40,6 @@ $client = new FingerprintApi(
     $config
 );
 
-// Temporarily suppress a million deprecated ArrayAccess return type warnings for readability
-// Our SDK generator does not yet support PHP's new attributes system
-// https://github.com/swagger-api/swagger-codegen/issues/11820
-error_reporting(error_reporting() & ~E_DEPRECATED);
-
 // FingerprintApi->searchEvents usage example
 try {
     // 3 month from now

--- a/run_checks.php
+++ b/run_checks.php
@@ -1,10 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 require_once __DIR__.'/vendor/autoload.php';
 
-$host = getenv('FP_API_HOST');
-$api_key = getenv('FP_PRIVATE_API_KEY');
-
+use Dotenv\Dotenv;
 use Fingerprint\ServerAPI\Api\FingerprintApi;
 use Fingerprint\ServerAPI\Configuration;
 use Fingerprint\ServerAPI\Model\EventsGetResponse;
@@ -14,24 +14,34 @@ use Fingerprint\ServerAPI\Model\SearchEventsResponse;
 use Fingerprint\ServerAPI\Webhook\WebhookVerifier;
 use GuzzleHttp\Client;
 
-$dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+$host = getenv('FP_API_HOST');
+$api_key = getenv('FP_PRIVATE_API_KEY');
 
+$dotenv = Dotenv::createImmutable(__DIR__);
 $dotenv->safeLoad();
 
-$api_key = $_ENV['FP_PRIVATE_API_KEY'] ?? getenv('FP_PRIVATE_API_KEY') ?? 'Private API Key not defined';
-$visitor_id_to_delete = $_ENV['FP_VISITOR_ID_TO_DELETE'] ?? getenv('FP_VISITOR_ID_TO_DELETE') ?? false;
-$request_id_to_update = $_ENV['FP_REQUEST_ID_TO_UPDATE'] ?? getenv('FP_REQUEST_ID_TO_UPDATE') ?? false;
-$region_env = $_ENV['FP_REGION'] ?? getenv('FP_REGION') ?? 'us';
-
-$region = Configuration::REGION_GLOBAL;
-if ('eu' === $region_env) {
-    $region = Configuration::REGION_EUROPE;
-} elseif ('ap' === $region_env) {
-    $region = Configuration::REGION_ASIA;
+function env(string $key, ?string $default = null): ?string
+{
+    return $_ENV[$key] ?? getenv($key) ?: $default;
 }
 
+$apiKey = env('FP_PRIVATE_API_KEY');
+if (!$apiKey) {
+    throw new Exception('FP_PRIVATE_API_KEY is not defined.');
+}
+
+$regionEnv = env('FP_REGION', 'us');
+$visitorIdToDelete = env('FP_VISITOR_ID_TO_DELETE');
+$requestIdToUpdate = env('FP_REQUEST_ID_TO_UPDATE');
+
+$region = match(strtolower(trim($regionEnv))) {
+    'eu' => Configuration::REGION_EUROPE,
+    'ap' => Configuration::REGION_ASIA,
+    default => Configuration::REGION_GLOBAL,
+};
+
 $config = Configuration::getDefaultConfiguration(
-    $api_key,
+    $apiKey,
     $region,
 );
 
@@ -40,20 +50,19 @@ $client = new FingerprintApi(
     $config
 );
 
+$start = (new DateTime())->sub(new DateInterval('P3M'));
+$end = new DateTime();
+
 // FingerprintApi->searchEvents usage example
 try {
-    // 3 month from now
-    $start = (new DateTime())->sub(new DateInterval('P3M'));
-    $end = new DateTime();
-
     /** @var SearchEventsResponse $result */
     list($result, $response) = $client->searchEvents(10, start: $start->getTimestamp() * 1000, end: $end->getTimestamp() * 1000);
     if (!is_countable($result->getEvents()) || count($result->getEvents()) === 0) {
         throw new Exception('No events found');
     }
-    $identification_data = $result->getEvents()[0]->getProducts()->getIdentification()->getData();
-    $visitor_id = $identification_data->getVisitorId();
-    $request_id = $identification_data->getRequestId();
+    $identificationData = $result->getEvents()[0]->getProducts()->getIdentification()->getData();
+    $visitorId = $identificationData->getVisitorId();
+    $requestId = $identificationData->getRequestId();
     fwrite(STDOUT, sprintf("\n\nGot events: %s \n", $response->getBody()->getContents()));
 } catch (Exception $e) {
     fwrite(STDERR, sprintf("\n\nException when calling FingerprintApi->searchEvents: %s\n", $e->getMessage()));
@@ -64,8 +73,8 @@ try {
 // FingerprintApi->getVisits usage example
 try {
     /** @var VisitorsGetResponse $result */
-    list($result, $response) = $client->getVisits($visitor_id);
-    if ($result->getVisitorId() !== $visitor_id) {
+    list($result, $response) = $client->getVisits($visitorId);
+    if ($result->getVisitorId() !== $visitorId) {
         throw new Exception('Argument visitorId is not equal to deserialized getVisitorId');
     }
     fwrite(STDOUT, sprintf("Got visits: %s \n", $response->getBody()->getContents()));
@@ -76,9 +85,9 @@ try {
 }
 
 // FingerprintApi->deleteVisitorData usage example
-if ($visitor_id_to_delete) {
+if ($visitorIdToDelete) {
     try {
-        list($model, $response) = $client->deleteVisitorData($visitor_id_to_delete);
+        list($model, $response) = $client->deleteVisitorData($visitorIdToDelete);
         fwrite(STDOUT, sprintf("Visitor data deleted: %s \n", $response->getBody()->getContents()));
     } catch (Exception $e) {
         fwrite(STDERR, sprintf("Exception when calling FingerprintApi->deleteVisitorData: %s\n", $e->getMessage()));
@@ -89,8 +98,8 @@ if ($visitor_id_to_delete) {
 // FingerprintApi->getEvent usage example
 try {
     /** @var EventsGetResponse $result */
-    list($result, $response) = $client->getEvent($request_id);
-    if ($result->getProducts()->getIdentification()->getData()->getRequestId() !== $request_id) {
+    list($result, $response) = $client->getEvent($requestId);
+    if ($result->getProducts()->getIdentification()->getData()->getRequestId() !== $requestId) {
         throw new Exception('Argument requestId is not equal to deserialized getRequestId');
     }
     fwrite(STDOUT, sprintf("\n\nGot event: %s \n", $response->getBody()->getContents()));
@@ -101,24 +110,24 @@ try {
 }
 
 // FingerprintApi->updateEvent usage example
-if ($request_id_to_update) {
+if ($requestIdToUpdate) {
     try {
         $body = new EventsUpdateRequest([
             'linked_id' => date('Y-m-d H:i:s'),
         ]);
-        list($model, $response) = $client->updateEvent($body, $request_id_to_update);
+        list($model, $response) = $client->updateEvent($body, $requestIdToUpdate);
         fwrite(STDOUT, sprintf("\n\nEvent updated: %s \n", $response->getBody()->getContents()));
     } catch (Exception $e) {
-        fwrite("\n\nException when calling FingerprintApi->updateEvent: %s\n", $e->getMessage());
+        fwrite(STDOUT, sprintf("\n\nException when calling FingerprintApi->updateEvent: %s\n", $e->getMessage()));
         exit(1);
     }
 }
 
 // Call API asynchronously examples
-$eventPromise = $client->getEventAsync($request_id);
-$eventPromise->then(function ($tuple) use ($request_id) {
+$eventPromise = $client->getEventAsync($requestId);
+$eventPromise->then(function ($tuple) use ($requestId) {
     list($result, $response) = $tuple;
-    if ($result->getProducts()->getIdentification()->getData()->getRequestId() !== $request_id) {
+    if ($result->getProducts()->getIdentification()->getData()->getRequestId() !== $requestId) {
         throw new Exception('Argument requestId is not equal to deserialized getRequestId');
     }
     fwrite(STDOUT, sprintf("\n\nGot async event: %s \n", $response->getBody()->getContents()));
@@ -128,10 +137,10 @@ $eventPromise->then(function ($tuple) use ($request_id) {
     exit(1);
 })->wait();
 
-$visitsPromise = $client->getVisitsAsync($visitor_id);
-$visitsPromise->then(function ($tuple) use ($visitor_id) {
+$visitsPromise = $client->getVisitsAsync($visitorId);
+$visitsPromise->then(function ($tuple) use ($visitorId) {
     list($result, $response) = $tuple;
-    if ($result->getVisitorId() !== $visitor_id) {
+    if ($result->getVisitorId() !== $visitorId) {
         throw new Exception('Argument visitorId is not equal to deserialized getVisitorId');
     }
     fwrite(STDOUT, sprintf("\n\nGot async visits: %s \n", $response->getBody()->getContents()));
@@ -147,36 +156,33 @@ $webhookData = 'data';
 $webhookHeader = 'v1=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db';
 $isValidWebhookSign = WebhookVerifier::IsValidWebhookSignature($webhookHeader, $webhookData, $webhookSecret);
 if ($isValidWebhookSign) {
-    fwrite(STDOUT, sprintf("\n\nVerified webhook signature\n"));
+    fwrite(STDOUT, "\n\nVerified webhook signature\n");
 } else {
-    fwrite(STDERR, sprintf("\n\nWebhook signature verification failed\n"));
+    fwrite(STDERR, "\n\nWebhook signature verification failed\n");
 
     exit(1);
 }
 
 // Check that old events still match expected format
 try {
-    list($result_old) = $client->searchEvents(1, start: $start->getTimestamp() * 1000, end: $end->getTimestamp() * 1000, reverse: true);
-    if (!is_countable($result_old->getEvents()) || count($result_old->getEvents()) === 0) {
+    list($resultOld) = $client->searchEvents(1, start: $start->getTimestamp() * 1000, end: $end->getTimestamp() * 1000, reverse: true);
+    if (!is_countable($resultOld->getEvents()) || count($resultOld->getEvents()) === 0) {
         throw new Exception('No old events found');
     }
-    $identification_data_old = $result_old->getEvents()[0]->getProducts()->getIdentification()->getData();
-    $visitor_id_old = $identification_data_old->getVisitorId();
-    $request_id_old = $identification_data_old->getRequestId();
+    $identificationDataOld = $resultOld->getEvents()[0]->getProducts()->getIdentification()->getData();
+    $visitorIdOld = $identificationDataOld->getVisitorId();
+    $requestIdOld = $identificationDataOld->getRequestId();
 
-    if ($visitor_id === $visitor_id_old || $request_id === $request_id_old) {
+    if ($requestId === $requestIdOld) {
         throw new Exception('Old events are identical to new');
     }
 
-    list($result, $response) = $client->getEvent($request_id_old);
-    list($result, $response) = $client->getVisits($visitor_id_old);
-    fwrite(STDERR, sprintf("\n\nOld events are good\n"));
+    list($result, $response) = $client->getEvent($requestIdOld);
+    list($result, $response) = $client->getVisits($visitorIdOld);
+    fwrite(STDERR, "\n\nOld events are good\n");
 }  catch (Exception $e) {
     fwrite(STDERR, sprintf("\n\nException when trying to read old data: %s\n", $e->getMessage()));
 }
-
-// Enable the deprecated ArrayAccess return type warning again if needed
-error_reporting(error_reporting() | E_DEPRECATED);
 
 fwrite(STDOUT, "\n\nChecks passed\n");
 


### PR DESCRIPTION
Made the functional test script simpler. We no longer compare `visitorId` between recent and oldest events. 

## ✏️  What Changed?

- Compare old vs new events by `requestId` only (removed `visitorId` check) so repeated visitors don't fail the check.
- Add `declare(strict_types=1)`.
- Centralize env access with `env()`.
- Use `match()` for region selection.
- Normalize variable names to camelCase.