### PR TITLE
INTER-1948: Update repository URL to `php-sdk`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": [
     "@fingerprintjs/changesets-changelog-format",
     {
-      "repo": "fingerprintjs/fingerprint-pro-server-api-php-sdk"
+      "repo": "fingerprintjs/php-sdk"
     }
   ],
   "commit": false,

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 </a>
 </p>
 <p align="center">
-<a href="https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/actions/workflows/release.yml"><img src="https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/actions/workflows/release.yml/badge.svg" alt="CI badge" /></a>
-<a href="https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/actions/workflows/test.yml"><img src="https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/actions/workflows/test.yml/badge.svg" alt="CI badge" /></a>
-<a href="https://fingerprintjs.github.io/fingerprint-pro-server-api-php-sdk"><img src="https://fingerprintjs.github.io/fingerprint-pro-server-api-php-sdk/coverage.svg" alt="Unit Test Coverage" /></a>
-<a href="https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/actions/workflows/functional.yml"><img src="https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/actions/workflows/functional.yml/badge.svg" alt="CI badge" /></a>
+<a href="https://github.com/fingerprintjs/php-sdk/actions/workflows/release.yml"><img src="https://github.com/fingerprintjs/php-sdk/actions/workflows/release.yml/badge.svg" alt="CI badge" /></a>
+<a href="https://github.com/fingerprintjs/php-sdk/actions/workflows/test.yml"><img src="https://github.com/fingerprintjs/php-sdk/actions/workflows/test.yml/badge.svg" alt="CI badge" /></a>
+<a href="https://fingerprintjs.github.io/php-sdk"><img src="https://fingerprintjs.github.io/php-sdk/coverage.svg" alt="Unit Test Coverage" /></a>
+<a href="https://github.com/fingerprintjs/php-sdk/actions/workflows/functional.yml"><img src="https://github.com/fingerprintjs/php-sdk/actions/workflows/functional.yml/badge.svg" alt="CI badge" /></a>
 <a href="https://packagist.org/packages/fingerprint/fingerprint-pro-server-api-sdk"><img src="https://poser.pugx.org/fingerprint/fingerprint-pro-server-api-sdk/v" alt="Latest Stable Version on Packagist"></a>
 <a href="https://packagist.org/packages/fingerprint/fingerprint-pro-server-api-sdk"><img src="https://poser.pugx.org/fingerprint/fingerprint-pro-server-api-sdk/require/php?style=flat-square" alt="PHP Version Require"></a>
 <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/:license-mit-blue.svg?style=flat"/></a>
@@ -403,9 +403,9 @@ composer install
 
 ## Support
 
-To report problems, ask questions or provide feedback, please use [Issues](https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/issues).
+To report problems, ask questions or provide feedback, please use [Issues](https://github.com/fingerprintjs/php-sdk/issues).
 If you need private support, you can email us at [oss-support@fingerprint.com](mailto:oss-support@fingerprint.com).
 
 ## License
 
-This project is licensed under the [MIT License](https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/blob/main/LICENSE).
+This project is licensed under the [MIT License](https://github.com/fingerprintjs/php-sdk/blob/main/LICENSE).

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "authors": [
         {
             "name": "fingerprint",
-            "homepage": "https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk"
+            "homepage": "https://github.com/fingerprintjs/php-sdk"
         }
     ],
     "require": {

--- a/config.json
+++ b/config.json
@@ -4,9 +4,9 @@
   "invokerPackage": "Fingerprint\\ServerAPI",
   "composerVendorName": "fingerprint",
   "composerProjectName": "fingerprint-pro-server-api-sdk",
-  "packageUrl": "https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk",
+  "packageUrl": "https://github.com/fingerprintjs/php-sdk",
   "gitUserId": "fingerprintjs",
-  "gitRepoId": "fingerprint-pro-server-api-php-sdk",
+  "gitRepoId": "php-sdk",
   "description": "Fingerprint Pro Server API provides a way for validating visitors’ data issued by Fingerprint Pro.",
   "artifactVersion": "6.10.0"
 }

--- a/template/README.mustache
+++ b/template/README.mustache
@@ -8,10 +8,10 @@
 </a>
 </p>
 <p align="center">
-<a href="https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/actions/workflows/release.yml"><img src="https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/actions/workflows/release.yml/badge.svg" alt="CI badge" /></a>
-<a href="https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/actions/workflows/test.yml"><img src="https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/actions/workflows/test.yml/badge.svg" alt="CI badge" /></a>
-<a href="https://fingerprintjs.github.io/fingerprint-pro-server-api-php-sdk"><img src="https://fingerprintjs.github.io/fingerprint-pro-server-api-php-sdk/coverage.svg" alt="Unit Test Coverage" /></a>
-<a href="https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/actions/workflows/functional.yml"><img src="https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/actions/workflows/functional.yml/badge.svg" alt="CI badge" /></a>
+<a href="https://github.com/fingerprintjs/php-sdk/actions/workflows/release.yml"><img src="https://github.com/fingerprintjs/php-sdk/actions/workflows/release.yml/badge.svg" alt="CI badge" /></a>
+<a href="https://github.com/fingerprintjs/php-sdk/actions/workflows/test.yml"><img src="https://github.com/fingerprintjs/php-sdk/actions/workflows/test.yml/badge.svg" alt="CI badge" /></a>
+<a href="https://fingerprintjs.github.io/php-sdk"><img src="https://fingerprintjs.github.io/php-sdk/coverage.svg" alt="Unit Test Coverage" /></a>
+<a href="https://github.com/fingerprintjs/php-sdk/actions/workflows/functional.yml"><img src="https://github.com/fingerprintjs/php-sdk/actions/workflows/functional.yml/badge.svg" alt="CI badge" /></a>
 <a href="https://packagist.org/packages/fingerprint/fingerprint-pro-server-api-sdk"><img src="https://poser.pugx.org/fingerprint/fingerprint-pro-server-api-sdk/v" alt="Latest Stable Version on Packagist"></a>
 <a href="https://packagist.org/packages/fingerprint/fingerprint-pro-server-api-sdk"><img src="https://poser.pugx.org/fingerprint/fingerprint-pro-server-api-sdk/require/php?style=flat-square" alt="PHP Version Require"></a>
 <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/:license-mit-blue.svg?style=flat"/></a>
@@ -308,9 +308,9 @@ composer install
 
 ## Support
 
-To report problems, ask questions or provide feedback, please use [Issues](https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/issues).
+To report problems, ask questions or provide feedback, please use [Issues](https://github.com/fingerprintjs/php-sdk/issues).
 If you need private support, you can email us at [oss-support@fingerprint.com](mailto:oss-support@fingerprint.com).
 
 ## License
 
-This project is licensed under the [MIT License](https://github.com/fingerprintjs/fingerprint-pro-server-api-php-sdk/blob/main/LICENSE).
+This project is licensed under the [MIT License](https://github.com/fingerprintjs/php-sdk/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

- Updated all references from `fingerprint-pro-server-api-php-sdk` to `php-sdk` for the repository rename.
- Updated badge URLs, issues link, and license link in the `README.md`.

> [!NOTE]
> This PR only updates internal repository URLs. No changeset needed.