### PR TITLE
fix: maintain fractional part of DateTime when formatting

### DIFF
--- a/.changeset/sour-eagles-notice.md
+++ b/.changeset/sour-eagles-notice.md
@@ -1,0 +1,5 @@
+---
+"@fingerprint/php-sdk": patch
+---
+
+temporary changeset: fix date-time formatting in query parameters

--- a/src/ObjectSerializer.php
+++ b/src/ObjectSerializer.php
@@ -42,7 +42,7 @@ use Fingerprint\ServerSdk\Model\ModelInterface;
  */
 class ObjectSerializer
 {
-    private static string $dateTimeFormat = \DateTimeInterface::ATOM;
+    private static string $dateTimeFormat = \DateTimeInterface::RFC3339_EXTENDED;
 
     /**
      * Change the date format.

--- a/template/ObjectSerializer.mustache
+++ b/template/ObjectSerializer.mustache
@@ -31,7 +31,7 @@ use {{modelPackage}}\ModelInterface;
  */
 class ObjectSerializer
 {
-    private static string $dateTimeFormat = \DateTimeInterface::ATOM;
+    private static string $dateTimeFormat = \DateTimeInterface::RFC3339_EXTENDED;
 
     /**
      * Change the date format

--- a/test/Api/FingerprintApiTest.php
+++ b/test/Api/FingerprintApiTest.php
@@ -680,7 +680,7 @@ class FingerprintApiTest extends TestCase
             'bundle_id' => 'bundle_id',
             'package_name' => 'package_name',
             'origin' => 'origin',
-            'start' => [$startDate, $startDate->format(\DateTimeInterface::RFC3339)],
+            'start' => [$startDate, '2020-01-01T00:00:00.000+00:00'],
             'end' => $endDate->getTimestamp(),
             'reverse' => true,
             'suspect' => true,


### PR DESCRIPTION
- Update `ObjectSerializer.mustache` to use the RFC3339_EXTENDED format to maintain the fractional part (i.e., the milliseconds) of the DateTime when formatting it as a string. This allows a DateTime to be created with milliseconds and have it be maintained when sending as a query parameter.