### PR TITLE
Use fixed 89-day window for run_checks

### DIFF
--- a/run_checks.php
+++ b/run_checks.php
@@ -47,7 +47,7 @@ $client = new FingerprintApi(
     new Client()
 );
 
-$start = (new DateTime())->sub(new DateInterval('P3M'));
+$start = (new DateTime())->sub(new DateInterval('P89D'));
 $end = new DateTime();
 
 // FingerprintApi->searchEvents usage example


### PR DESCRIPTION
## Problem

`run_checks.php` calculated the `searchEvents` start time using a 3-month (`P3M`) interval. Because PHP's `DateInterval` with months is calendar-based, this can resolve to 89+ days depending on which months are spanned/included.

The Fingerprint API rejects start times older than 90 days, so the check script would fail.

## Fix

Replace `P3M` with `P89D` to use a fixed 89-day window, which always stays within the API limit regardless of the calendar month.