### PR TITLE
INTER-2244: Allow unknown enum values

### DIFF
--- a/.changeset/allow-unknown-enum-values.md
+++ b/.changeset/allow-unknown-enum-values.md
@@ -1,0 +1,5 @@
+---
+"@fingerprint/php-sdk": patch
+---
+
+Allow unknown enum values to prevent SDK breakage when new values are added server-side.

--- a/src/Model/BotInfo.php
+++ b/src/Model/BotInfo.php
@@ -318,25 +318,8 @@ class BotInfo implements ModelInterface, \ArrayAccess, \JsonSerializable
         if (null === $this->container['identity']) {
             $invalidProperties[] = "'identity' can't be null";
         }
-        $allowedValues = $this->getIdentityAllowableValues();
-        if (!is_null($this->container['identity']) && !in_array($this->container['identity'], $allowedValues, true)) {
-            $invalidProperties[] = sprintf(
-                "invalid value '%s' for 'identity', must be one of '%s'",
-                $this->container['identity'],
-                implode("', '", $allowedValues)
-            );
-        }
-
         if (null === $this->container['confidence']) {
             $invalidProperties[] = "'confidence' can't be null";
-        }
-        $allowedValues = $this->getConfidenceAllowableValues();
-        if (!is_null($this->container['confidence']) && !in_array($this->container['confidence'], $allowedValues, true)) {
-            $invalidProperties[] = sprintf(
-                "invalid value '%s' for 'confidence', must be one of '%s'",
-                $this->container['confidence'],
-                implode("', '", $allowedValues)
-            );
         }
 
         return $invalidProperties;
@@ -458,16 +441,6 @@ class BotInfo implements ModelInterface, \ArrayAccess, \JsonSerializable
      */
     public function setIdentity(string $identity): self
     {
-        $allowedValues = $this->getIdentityAllowableValues();
-        if (!in_array($identity, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "Invalid value '%s' for 'identity', must be one of '%s'",
-                    $identity,
-                    implode("', '", $allowedValues)
-                )
-            );
-        }
         $this->container['identity'] = $identity;
 
         return $this;
@@ -490,16 +463,6 @@ class BotInfo implements ModelInterface, \ArrayAccess, \JsonSerializable
      */
     public function setConfidence(string $confidence): self
     {
-        $allowedValues = $this->getConfidenceAllowableValues();
-        if (!in_array($confidence, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "Invalid value '%s' for 'confidence', must be one of '%s'",
-                    $confidence,
-                    implode("', '", $allowedValues)
-                )
-            );
-        }
         $this->container['confidence'] = $confidence;
 
         return $this;

--- a/src/Model/Error.php
+++ b/src/Model/Error.php
@@ -263,8 +263,9 @@ class Error implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets code.
      *
+     * @return ErrorCode|null
      */
-    public function getCode(): ?ErrorCode
+    public function getCode(): ErrorCode|string|null
     {
         return $this->container['code'];
     }
@@ -275,7 +276,7 @@ class Error implements ModelInterface, \ArrayAccess, \JsonSerializable
      * @param ErrorCode $code code
      *
      */
-    public function setCode(ErrorCode $code): self
+    public function setCode(ErrorCode|string $code): self
     {
         $this->container['code'] = $code;
 

--- a/src/Model/Error.php
+++ b/src/Model/Error.php
@@ -263,7 +263,6 @@ class Error implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets code.
      *
-     * @return ErrorCode|null
      */
     public function getCode(): ErrorCode|string|null
     {
@@ -273,7 +272,7 @@ class Error implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Sets code.
      *
-     * @param ErrorCode $code code
+     * @param ErrorCode|string $code code
      *
      */
     public function setCode(ErrorCode|string $code): self

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -731,8 +731,9 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets incremental_identification_status.
      *
+     * @return IncrementalIdentificationStatus|null
      */
-    public function getIncrementalIdentificationStatus(): ?IncrementalIdentificationStatus
+    public function getIncrementalIdentificationStatus(): IncrementalIdentificationStatus|string|null
     {
         return $this->container['incremental_identification_status'];
     }
@@ -743,7 +744,7 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
      * @param IncrementalIdentificationStatus $incremental_identification_status incremental_identification_status
      *
      */
-    public function setIncrementalIdentificationStatus(IncrementalIdentificationStatus $incremental_identification_status): self
+    public function setIncrementalIdentificationStatus(IncrementalIdentificationStatus|string $incremental_identification_status): self
     {
         $this->container['incremental_identification_status'] = $incremental_identification_status;
 
@@ -1106,8 +1107,9 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets bot.
      *
+     * @return BotResult|null
      */
-    public function getBot(): ?BotResult
+    public function getBot(): BotResult|string|null
     {
         return $this->container['bot'];
     }
@@ -1118,7 +1120,7 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
      * @param BotResult $bot bot
      *
      */
-    public function setBot(BotResult $bot): self
+    public function setBot(BotResult|string $bot): self
     {
         $this->container['bot'] = $bot;
 
@@ -1348,8 +1350,9 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets proxy_confidence.
      *
+     * @return ProxyConfidence|null
      */
-    public function getProxyConfidence(): ?ProxyConfidence
+    public function getProxyConfidence(): ProxyConfidence|string|null
     {
         return $this->container['proxy_confidence'];
     }
@@ -1360,7 +1363,7 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
      * @param ProxyConfidence $proxy_confidence proxy_confidence
      *
      */
-    public function setProxyConfidence(ProxyConfidence $proxy_confidence): self
+    public function setProxyConfidence(ProxyConfidence|string $proxy_confidence): self
     {
         $this->container['proxy_confidence'] = $proxy_confidence;
 
@@ -1641,8 +1644,9 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets tampering_confidence.
      *
+     * @return TamperingConfidence|null
      */
-    public function getTamperingConfidence(): ?TamperingConfidence
+    public function getTamperingConfidence(): string|TamperingConfidence|null
     {
         return $this->container['tampering_confidence'];
     }
@@ -1653,7 +1657,7 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
      * @param TamperingConfidence $tampering_confidence tampering_confidence
      *
      */
-    public function setTamperingConfidence(TamperingConfidence $tampering_confidence): self
+    public function setTamperingConfidence(string|TamperingConfidence $tampering_confidence): self
     {
         $this->container['tampering_confidence'] = $tampering_confidence;
 
@@ -1809,8 +1813,9 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets vpn_confidence.
      *
+     * @return VpnConfidence|null
      */
-    public function getVpnConfidence(): ?VpnConfidence
+    public function getVpnConfidence(): string|VpnConfidence|null
     {
         return $this->container['vpn_confidence'];
     }
@@ -1821,7 +1826,7 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
      * @param VpnConfidence $vpn_confidence vpn_confidence
      *
      */
-    public function setVpnConfidence(VpnConfidence $vpn_confidence): self
+    public function setVpnConfidence(string|VpnConfidence $vpn_confidence): self
     {
         $this->container['vpn_confidence'] = $vpn_confidence;
 
@@ -1941,8 +1946,9 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets rare_device_percentile_bucket.
      *
+     * @return RareDevicePercentileBucket|null
      */
-    public function getRareDevicePercentileBucket(): ?RareDevicePercentileBucket
+    public function getRareDevicePercentileBucket(): RareDevicePercentileBucket|string|null
     {
         return $this->container['rare_device_percentile_bucket'];
     }
@@ -1953,7 +1959,7 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
      * @param RareDevicePercentileBucket $rare_device_percentile_bucket rare_device_percentile_bucket
      *
      */
-    public function setRareDevicePercentileBucket(RareDevicePercentileBucket $rare_device_percentile_bucket): self
+    public function setRareDevicePercentileBucket(RareDevicePercentileBucket|string $rare_device_percentile_bucket): self
     {
         $this->container['rare_device_percentile_bucket'] = $rare_device_percentile_bucket;
 

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -731,7 +731,6 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets incremental_identification_status.
      *
-     * @return IncrementalIdentificationStatus|null
      */
     public function getIncrementalIdentificationStatus(): IncrementalIdentificationStatus|string|null
     {
@@ -741,7 +740,7 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Sets incremental_identification_status.
      *
-     * @param IncrementalIdentificationStatus $incremental_identification_status incremental_identification_status
+     * @param IncrementalIdentificationStatus|string $incremental_identification_status incremental_identification_status
      *
      */
     public function setIncrementalIdentificationStatus(IncrementalIdentificationStatus|string $incremental_identification_status): self
@@ -1107,7 +1106,6 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets bot.
      *
-     * @return BotResult|null
      */
     public function getBot(): BotResult|string|null
     {
@@ -1117,7 +1115,7 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Sets bot.
      *
-     * @param BotResult $bot bot
+     * @param BotResult|string $bot bot
      *
      */
     public function setBot(BotResult|string $bot): self
@@ -1350,7 +1348,6 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets proxy_confidence.
      *
-     * @return ProxyConfidence|null
      */
     public function getProxyConfidence(): ProxyConfidence|string|null
     {
@@ -1360,7 +1357,7 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Sets proxy_confidence.
      *
-     * @param ProxyConfidence $proxy_confidence proxy_confidence
+     * @param ProxyConfidence|string $proxy_confidence proxy_confidence
      *
      */
     public function setProxyConfidence(ProxyConfidence|string $proxy_confidence): self
@@ -1644,7 +1641,6 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets tampering_confidence.
      *
-     * @return TamperingConfidence|null
      */
     public function getTamperingConfidence(): string|TamperingConfidence|null
     {
@@ -1654,7 +1650,7 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Sets tampering_confidence.
      *
-     * @param TamperingConfidence $tampering_confidence tampering_confidence
+     * @param TamperingConfidence|string $tampering_confidence tampering_confidence
      *
      */
     public function setTamperingConfidence(string|TamperingConfidence $tampering_confidence): self
@@ -1813,7 +1809,6 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets vpn_confidence.
      *
-     * @return VpnConfidence|null
      */
     public function getVpnConfidence(): string|VpnConfidence|null
     {
@@ -1823,7 +1818,7 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Sets vpn_confidence.
      *
-     * @param VpnConfidence $vpn_confidence vpn_confidence
+     * @param VpnConfidence|string $vpn_confidence vpn_confidence
      *
      */
     public function setVpnConfidence(string|VpnConfidence $vpn_confidence): self
@@ -1946,7 +1941,6 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets rare_device_percentile_bucket.
      *
-     * @return RareDevicePercentileBucket|null
      */
     public function getRareDevicePercentileBucket(): RareDevicePercentileBucket|string|null
     {
@@ -1956,7 +1950,7 @@ class Event implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Sets rare_device_percentile_bucket.
      *
-     * @param RareDevicePercentileBucket $rare_device_percentile_bucket rare_device_percentile_bucket
+     * @param RareDevicePercentileBucket|string $rare_device_percentile_bucket rare_device_percentile_bucket
      *
      */
     public function setRareDevicePercentileBucket(RareDevicePercentileBucket|string $rare_device_percentile_bucket): self

--- a/src/Model/EventRuleAction.php
+++ b/src/Model/EventRuleAction.php
@@ -376,8 +376,9 @@ class EventRuleAction implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets type.
      *
+     * @return RuleActionType|null
      */
-    public function getType(): ?RuleActionType
+    public function getType(): RuleActionType|string|null
     {
         return $this->container['type'];
     }
@@ -388,7 +389,7 @@ class EventRuleAction implements ModelInterface, \ArrayAccess, \JsonSerializable
      * @param RuleActionType $type type
      *
      */
-    public function setType(RuleActionType $type): self
+    public function setType(RuleActionType|string $type): self
     {
         $this->container['type'] = $type;
 

--- a/src/Model/EventRuleAction.php
+++ b/src/Model/EventRuleAction.php
@@ -376,7 +376,6 @@ class EventRuleAction implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Gets type.
      *
-     * @return RuleActionType|null
      */
     public function getType(): RuleActionType|string|null
     {
@@ -386,7 +385,7 @@ class EventRuleAction implements ModelInterface, \ArrayAccess, \JsonSerializable
     /**
      * Sets type.
      *
-     * @param RuleActionType $type type
+     * @param RuleActionType|string $type type
      *
      */
     public function setType(RuleActionType|string $type): self

--- a/src/Model/EventRuleActionAllow.php
+++ b/src/Model/EventRuleActionAllow.php
@@ -352,7 +352,6 @@ class EventRuleActionAllow implements ModelInterface, \ArrayAccess, \JsonSeriali
     /**
      * Gets type.
      *
-     * @return RuleActionType|null
      */
     public function getType(): RuleActionType|string|null
     {
@@ -362,7 +361,7 @@ class EventRuleActionAllow implements ModelInterface, \ArrayAccess, \JsonSeriali
     /**
      * Sets type.
      *
-     * @param RuleActionType $type type
+     * @param RuleActionType|string $type type
      *
      */
     public function setType(RuleActionType|string $type): self

--- a/src/Model/EventRuleActionAllow.php
+++ b/src/Model/EventRuleActionAllow.php
@@ -352,8 +352,9 @@ class EventRuleActionAllow implements ModelInterface, \ArrayAccess, \JsonSeriali
     /**
      * Gets type.
      *
+     * @return RuleActionType|null
      */
-    public function getType(): ?RuleActionType
+    public function getType(): RuleActionType|string|null
     {
         return $this->container['type'];
     }
@@ -364,7 +365,7 @@ class EventRuleActionAllow implements ModelInterface, \ArrayAccess, \JsonSeriali
      * @param RuleActionType $type type
      *
      */
-    public function setType(RuleActionType $type): self
+    public function setType(RuleActionType|string $type): self
     {
         $this->container['type'] = $type;
 

--- a/src/Model/EventRuleActionBlock.php
+++ b/src/Model/EventRuleActionBlock.php
@@ -366,7 +366,6 @@ class EventRuleActionBlock implements ModelInterface, \ArrayAccess, \JsonSeriali
     /**
      * Gets type.
      *
-     * @return RuleActionType|null
      */
     public function getType(): RuleActionType|string|null
     {
@@ -376,7 +375,7 @@ class EventRuleActionBlock implements ModelInterface, \ArrayAccess, \JsonSeriali
     /**
      * Sets type.
      *
-     * @param RuleActionType $type type
+     * @param RuleActionType|string $type type
      *
      */
     public function setType(RuleActionType|string $type): self

--- a/src/Model/EventRuleActionBlock.php
+++ b/src/Model/EventRuleActionBlock.php
@@ -366,8 +366,9 @@ class EventRuleActionBlock implements ModelInterface, \ArrayAccess, \JsonSeriali
     /**
      * Gets type.
      *
+     * @return RuleActionType|null
      */
-    public function getType(): ?RuleActionType
+    public function getType(): RuleActionType|string|null
     {
         return $this->container['type'];
     }
@@ -378,7 +379,7 @@ class EventRuleActionBlock implements ModelInterface, \ArrayAccess, \JsonSeriali
      * @param RuleActionType $type type
      *
      */
-    public function setType(RuleActionType $type): self
+    public function setType(RuleActionType|string $type): self
     {
         $this->container['type'] = $type;
 

--- a/src/Model/Proximity.php
+++ b/src/Model/Proximity.php
@@ -284,15 +284,6 @@ class Proximity implements ModelInterface, \ArrayAccess, \JsonSerializable
         if (null === $this->container['precision_radius']) {
             $invalidProperties[] = "'precision_radius' can't be null";
         }
-        $allowedValues = $this->getPrecisionRadiusAllowableValues();
-        if (!is_null($this->container['precision_radius']) && !in_array($this->container['precision_radius'], $allowedValues, true)) {
-            $invalidProperties[] = sprintf(
-                "invalid value '%s' for 'precision_radius', must be one of '%s'",
-                $this->container['precision_radius'],
-                implode("', '", $allowedValues)
-            );
-        }
-
         if (null === $this->container['confidence']) {
             $invalidProperties[] = "'confidence' can't be null";
         }
@@ -357,16 +348,6 @@ class Proximity implements ModelInterface, \ArrayAccess, \JsonSerializable
      */
     public function setPrecisionRadius(int $precision_radius): self
     {
-        $allowedValues = $this->getPrecisionRadiusAllowableValues();
-        if (!in_array($precision_radius, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "Invalid value '%s' for 'precision_radius', must be one of '%s'",
-                    $precision_radius,
-                    implode("', '", $allowedValues)
-                )
-            );
-        }
         $this->container['precision_radius'] = $precision_radius;
 
         return $this;

--- a/src/Model/ProxyDetails.php
+++ b/src/Model/ProxyDetails.php
@@ -267,14 +267,6 @@ class ProxyDetails implements ModelInterface, \ArrayAccess, \JsonSerializable
         if (null === $this->container['proxy_type']) {
             $invalidProperties[] = "'proxy_type' can't be null";
         }
-        $allowedValues = $this->getProxyTypeAllowableValues();
-        if (!is_null($this->container['proxy_type']) && !in_array($this->container['proxy_type'], $allowedValues, true)) {
-            $invalidProperties[] = sprintf(
-                "invalid value '%s' for 'proxy_type', must be one of '%s'",
-                $this->container['proxy_type'],
-                implode("', '", $allowedValues)
-            );
-        }
 
         return $invalidProperties;
     }
@@ -307,16 +299,6 @@ class ProxyDetails implements ModelInterface, \ArrayAccess, \JsonSerializable
      */
     public function setProxyType(string $proxy_type): self
     {
-        $allowedValues = $this->getProxyTypeAllowableValues();
-        if (!in_array($proxy_type, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "Invalid value '%s' for 'proxy_type', must be one of '%s'",
-                    $proxy_type,
-                    implode("', '", $allowedValues)
-                )
-            );
-        }
         $this->container['proxy_type'] = $proxy_type;
 
         return $this;

--- a/src/Model/SDK.php
+++ b/src/Model/SDK.php
@@ -271,15 +271,6 @@ class SDK implements ModelInterface, \ArrayAccess, \JsonSerializable
         if (null === $this->container['platform']) {
             $invalidProperties[] = "'platform' can't be null";
         }
-        $allowedValues = $this->getPlatformAllowableValues();
-        if (!is_null($this->container['platform']) && !in_array($this->container['platform'], $allowedValues, true)) {
-            $invalidProperties[] = sprintf(
-                "invalid value '%s' for 'platform', must be one of '%s'",
-                $this->container['platform'],
-                implode("', '", $allowedValues)
-            );
-        }
-
         if (null === $this->container['version']) {
             $invalidProperties[] = "'version' can't be null";
         }
@@ -315,16 +306,6 @@ class SDK implements ModelInterface, \ArrayAccess, \JsonSerializable
      */
     public function setPlatform(string $platform): self
     {
-        $allowedValues = $this->getPlatformAllowableValues();
-        if (!in_array($platform, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "Invalid value '%s' for 'platform', must be one of '%s'",
-                    $platform,
-                    implode("', '", $allowedValues)
-                )
-            );
-        }
         $this->container['platform'] = $platform;
 
         return $this;

--- a/src/ObjectSerializer.php
+++ b/src/ObjectSerializer.php
@@ -89,17 +89,6 @@ class ObjectSerializer
                     $value = $data->{$getter}();
                     if ($value instanceof \BackedEnum) {
                         $value = $value->value;
-                    } elseif (null !== $value && !in_array($openAPIType, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
-                        $callable = [$openAPIType, 'getAllowableEnumValues'];
-                        if (is_callable($callable)) {
-                            /** array $callable */
-                            $allowedEnumTypes = $callable();
-                            if (!in_array($value, $allowedEnumTypes, true)) {
-                                $imploded = implode("', '", $allowedEnumTypes);
-
-                                throw new \InvalidArgumentException("Invalid value for enum '$openAPIType', must be one of: '$imploded'");
-                            }
-                        }
                     }
                     if (($data::isNullable($property) && $data->isNullableSetToNull($property)) || null !== $value) {
                         $values[$data::attributeMap()[$property]] = self::sanitizeForSerialization($value, $formats[$property]);
@@ -423,14 +412,7 @@ class ObjectSerializer
 
         if (enum_exists($class)) {
             /* @var \BackedEnum $class */
-            try {
-                return $class::from($data);
-            } catch (\ValueError $e) {
-                $allowedValues = array_map(fn ($case) => $case->value, $class::cases());
-                $imploded = implode("', '", $allowedValues);
-
-                throw new \InvalidArgumentException("Invalid value for enum '$class', must be one of: '$imploded'", previous: $e);
-            }
+            return $class::tryFrom($data) ?? $data;
         }
 
         $data = is_string($data) ? json_decode($data) : $data;

--- a/template/ObjectSerializer.mustache
+++ b/template/ObjectSerializer.mustache
@@ -77,16 +77,6 @@ class ObjectSerializer
                     $value = $data->$getter();
                     if ($value instanceof \BackedEnum) {
                         $value = $value->value;
-                    } elseif ($value !== null && !in_array($openAPIType, [{{&primitives}}], true)) {
-                        $callable = [$openAPIType, 'getAllowableEnumValues'];
-                        if (is_callable($callable)) {
-                            /** array $callable */
-                            $allowedEnumTypes = $callable();
-                            if (!in_array($value, $allowedEnumTypes, true)) {
-                                $imploded = implode("', '", $allowedEnumTypes);
-                                throw new \InvalidArgumentException("Invalid value for enum '$openAPIType', must be one of: '$imploded'");
-                            }
-                        }
                     }
                     if (($data::isNullable($property) && $data->isNullableSetToNull($property)) || $value !== null) {
                         $values[$data::attributeMap()[$property]] = self::sanitizeForSerialization($value, $formats[$property]);
@@ -435,13 +425,7 @@ class ObjectSerializer
 
         if (enum_exists($class)) {
             /** @var \BackedEnum $class */
-            try {
-                return $class::from($data);
-            } catch (\ValueError $e) {
-                $allowedValues = array_map(fn ($case) => $case->value, $class::cases());
-                $imploded = implode("', '", $allowedValues);
-                throw new \InvalidArgumentException("Invalid value for enum '$class', must be one of: '$imploded'", previous: $e);
-            }
+            return $class::tryFrom($data) ?? $data;
         }
 
         $data = is_string($data) ? json_decode($data) : $data;

--- a/template/model_generic.mustache
+++ b/template/model_generic.mustache
@@ -355,7 +355,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * @deprecated
     {{/deprecated}}
      */
-    public function {{getter}}(): {{#isEnumRef}}null|{{/isEnumRef}}{{^isEnumRef}}?{{/isEnumRef}}{{#isArray}}array{{/isArray}}{{#isMap}}array{{/isMap}}{{^isArray}}{{^isMap}}{{{dataType}}}{{/isMap}}{{/isArray}}{{#isEnumRef}}|string{{/isEnumRef}}
+    public function {{getter}}(): {{^isEnumRef}}?{{/isEnumRef}}{{#isArray}}array{{/isArray}}{{#isMap}}array{{/isMap}}{{^isArray}}{{^isMap}}{{{dataType}}}{{/isMap}}{{/isArray}}{{#isEnumRef}}|string|null{{/isEnumRef}}
     {
         return $this->container['{{name}}'];
     }
@@ -370,7 +370,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * @deprecated
     {{/deprecated}}
      */
-    public function {{setter}}({{#isEnumRef}}{{#isNullable}}null|{{/isNullable}}{{/isEnumRef}}{{^isEnumRef}}{{#isNullable}}?{{/isNullable}}{{/isEnumRef}}{{#isArray}}array{{/isArray}}{{#isMap}}array{{/isMap}}{{^isArray}}{{^isMap}}{{{dataType}}}{{/isMap}}{{/isArray}}{{#isEnumRef}}|string{{/isEnumRef}} ${{name}}): self
+    public function {{setter}}({{^isEnumRef}}{{#isNullable}}?{{/isNullable}}{{/isEnumRef}}{{#isArray}}array{{/isArray}}{{#isMap}}array{{/isMap}}{{^isArray}}{{^isMap}}{{{dataType}}}{{/isMap}}{{/isArray}}{{#isEnumRef}}|string{{#isNullable}}|null{{/isNullable}}{{/isEnumRef}} ${{name}}): self
     {
         {{#isNullable}}
         if (is_null(${{name}})) {

--- a/template/model_generic.mustache
+++ b/template/model_generic.mustache
@@ -285,17 +285,6 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         }
         {{/required}}
         {{#isEnum}}
-        {{^isContainer}}
-        $allowedValues = $this->{{getter}}AllowableValues();
-        if (!is_null($this->container['{{name}}']) && !in_array($this->container['{{name}}'], $allowedValues, true)) {
-            $invalidProperties[] = sprintf(
-                "invalid value '%s' for '{{name}}', must be one of '%s'",
-                $this->container['{{name}}'],
-                implode("', '", $allowedValues)
-            );
-        }
-
-        {{/isContainer}}
         {{/isEnum}}
         {{#hasValidation}}
         {{#maxLength}}
@@ -366,7 +355,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * @deprecated
     {{/deprecated}}
      */
-    public function {{getter}}(): ?{{#isArray}}array{{/isArray}}{{#isMap}}array{{/isMap}}{{^isArray}}{{^isMap}}{{{dataType}}}{{/isMap}}{{/isArray}}
+    public function {{getter}}(): {{#isEnumRef}}null|{{/isEnumRef}}{{^isEnumRef}}?{{/isEnumRef}}{{#isArray}}array{{/isArray}}{{#isMap}}array{{/isMap}}{{^isArray}}{{^isMap}}{{{dataType}}}{{/isMap}}{{/isArray}}{{#isEnumRef}}|string{{/isEnumRef}}
     {
         return $this->container['{{name}}'];
     }
@@ -381,7 +370,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * @deprecated
     {{/deprecated}}
      */
-    public function {{setter}}({{#isNullable}}?{{/isNullable}}{{#isArray}}array{{/isArray}}{{#isMap}}array{{/isMap}}{{^isArray}}{{^isMap}}{{{dataType}}}{{/isMap}}{{/isArray}} ${{name}}): self
+    public function {{setter}}({{#isEnumRef}}{{#isNullable}}null|{{/isNullable}}{{/isEnumRef}}{{^isEnumRef}}{{#isNullable}}?{{/isNullable}}{{/isEnumRef}}{{#isArray}}array{{/isArray}}{{#isMap}}array{{/isMap}}{{^isArray}}{{^isMap}}{{{dataType}}}{{/isMap}}{{/isArray}}{{#isEnumRef}}|string{{/isEnumRef}} ${{name}}): self
     {
         {{#isNullable}}
         if (is_null(${{name}})) {
@@ -396,33 +385,6 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         }
         {{/isNullable}}
         {{#isEnum}}
-        $allowedValues = $this->{{getter}}AllowableValues();
-        {{^isContainer}}
-        if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}!in_array(${{{name}}}, $allowedValues, true)) {
-        {{#enumUnknownDefaultCase}}
-            ${{name}} = {{#allowableValues}}{{#enumVars}}{{#-last}}self::{{enumName}}_{{{name}}};{{/-last}}{{/enumVars}}{{/allowableValues}}
-        {{/enumUnknownDefaultCase}}
-        {{^enumUnknownDefaultCase}}
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "Invalid value '%s' for '{{name}}', must be one of '%s'",
-                    ${{{name}}},
-                    implode("', '", $allowedValues)
-                )
-            );
-        {{/enumUnknownDefaultCase}}
-        }
-        {{/isContainer}}
-        {{#isContainer}}
-        if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}array_diff(${{{name}}}, $allowedValues)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "Invalid value for '{{name}}', must be one of '%s'",
-                    implode("', '", $allowedValues)
-                )
-            );
-        }
-        {{/isContainer}}
         {{/isEnum}}
         {{#hasValidation}}
         {{#maxLength}}

--- a/template/model_generic.mustache
+++ b/template/model_generic.mustache
@@ -350,7 +350,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Gets {{name}}
      *
-     * @return {{{dataType}}}|null
+     * @return {{#isEnumRef}}{{{dataType}}}|string|null{{/isEnumRef}}{{^isEnumRef}}{{{dataType}}}|null{{/isEnumRef}}
     {{#deprecated}}
      * @deprecated
     {{/deprecated}}
@@ -363,7 +363,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Sets {{name}}
      *
-     * @param {{{dataType}}}{{#isNullable}}|null{{/isNullable}} ${{name}}{{#description}} {{{.}}}{{/description}}{{^description}} {{{name}}}{{/description}}
+     * @param {{#isEnumRef}}{{{dataType}}}|string{{/isEnumRef}}{{^isEnumRef}}{{{dataType}}}{{/isEnumRef}}{{#isNullable}}|null{{/isNullable}} ${{name}}{{#description}} {{{.}}}{{/description}}{{^description}} {{{name}}}{{/description}}
      *
      * @return self
     {{#deprecated}}

--- a/test/Model/BotInfoTest.php
+++ b/test/Model/BotInfoTest.php
@@ -81,25 +81,25 @@ class BotInfoTest extends TestCase
     }
 
     /**
-     * setIdentity should throw InvalidArgumentException for an invalid enum value.
+     * setIdentity should accept unknown enum values without throwing.
      */
-    public function testSetIdentityRejectsInvalidValue(): void
+    public function testSetIdentityAcceptsUnknownValue(): void
     {
         $model = new BotInfo();
 
-        $this->expectException(\InvalidArgumentException::class);
         $model->setIdentity('invalid');
+        $this->assertEquals('invalid', $model->getIdentity());
     }
 
     /**
-     * setConfidence should throw InvalidArgumentException for an invalid enum value.
+     * setConfidence should accept unknown enum values without throwing.
      */
-    public function testSetConfidenceRejectsInvalidValue(): void
+    public function testSetConfidenceAcceptsUnknownValue(): void
     {
         $model = new BotInfo();
 
-        $this->expectException(\InvalidArgumentException::class);
         $model->setConfidence('invalid');
+        $this->assertEquals('invalid', $model->getConfidence());
     }
 
     /**
@@ -218,9 +218,9 @@ class BotInfoTest extends TestCase
     }
 
     /**
-     * listInvalidProperties should report invalid enum values set via ArrayAccess bypass.
+     * listInvalidProperties should not report unknown enum values.
      */
-    public function testListInvalidPropertiesWithInvalidEnumValues(): void
+    public function testListInvalidPropertiesAcceptsUnknownEnumValues(): void
     {
         $model = new BotInfo(self::EXAMPLE);
 
@@ -228,18 +228,9 @@ class BotInfoTest extends TestCase
         $model['confidence'] = 'not_a_valid_confidence';
 
         $invalid = $model->listInvalidProperties();
-        $expected = "'".implode("', '", self::IDENTITY_VALUES)."'";
 
-        $this->assertContains(
-            "invalid value 'not_a_valid_identity' for 'identity', must be one of ".$expected,
-            $invalid
-        );
-
-        $expected = "'".implode("', '", self::CONFIDENCE_VALUES)."'";
-        $this->assertContains(
-            "invalid value 'not_a_valid_confidence' for 'confidence', must be one of ".$expected,
-            $invalid
-        );
+        $enumErrors = array_filter($invalid, fn ($msg) => str_contains($msg, 'invalid value'));
+        $this->assertEmpty($enumErrors, 'Unknown enum values should not produce invalid properties');
     }
 
     /**

--- a/test/Model/ProximityTest.php
+++ b/test/Model/ProximityTest.php
@@ -68,14 +68,14 @@ class ProximityTest extends TestCase
     }
 
     /**
-     * setPrecisionRadius should throw InvalidArgumentException for an invalid enum value.
+     * setPrecisionRadius should accept unknown enum values without throwing.
      */
-    public function testSetPrecisionRadiusRejectsInvalidValue(): void
+    public function testSetPrecisionRadiusAcceptsUnknownValue(): void
     {
         $model = new Proximity();
 
-        $this->expectException(\InvalidArgumentException::class);
         $model->setPrecisionRadius(999);
+        $this->assertEquals(999, $model->getPrecisionRadius());
     }
 
     /**
@@ -199,21 +199,18 @@ class ProximityTest extends TestCase
     }
 
     /**
-     * listInvalidProperties should report invalid enum values set via ArrayAccess bypass.
+     * listInvalidProperties should not report unknown enum values.
      */
-    public function testListInvalidPropertiesWithInvalidEnumValues(): void
+    public function testListInvalidPropertiesAcceptsUnknownEnumValues(): void
     {
         $model = new Proximity(self::EXAMPLE);
 
         $model['precision_radius'] = 999;
 
         $invalid = $model->listInvalidProperties();
-        $expected = "'".implode("', '", self::PRECISION_RADIUS_VALUES)."'";
 
-        $this->assertContains(
-            "invalid value '999' for 'precision_radius', must be one of ".$expected,
-            $invalid
-        );
+        $enumErrors = array_filter($invalid, fn ($msg) => str_contains($msg, 'invalid value'));
+        $this->assertEmpty($enumErrors, 'Unknown enum values should not produce invalid properties');
     }
 
     /**

--- a/test/Model/ProxyDetailsTest.php
+++ b/test/Model/ProxyDetailsTest.php
@@ -61,14 +61,14 @@ class ProxyDetailsTest extends TestCase
     }
 
     /**
-     * setProxyType should throw InvalidArgumentException for an invalid enum value.
+     * setProxyType should accept unknown enum values without throwing.
      */
-    public function testSetProxyTypeRejectsInvalidValue(): void
+    public function testSetProxyTypeAcceptsUnknownValue(): void
     {
         $model = new ProxyDetails();
 
-        $this->expectException(\InvalidArgumentException::class);
         $model->setProxyType('invalid');
+        $this->assertEquals('invalid', $model->getProxyType());
     }
 
     /**
@@ -170,21 +170,18 @@ class ProxyDetailsTest extends TestCase
     }
 
     /**
-     * listInvalidProperties should report invalid enum values set via ArrayAccess bypass.
+     * listInvalidProperties should not report unknown enum values.
      */
-    public function testListInvalidPropertiesWithInvalidEnumValues(): void
+    public function testListInvalidPropertiesAcceptsUnknownEnumValues(): void
     {
         $model = new ProxyDetails(self::EXAMPLE);
 
         $model['proxy_type'] = 'not_a_valid_proxy_type';
 
         $invalid = $model->listInvalidProperties();
-        $expected = "'".implode("', '", self::PROXY_TYPE_VALUES)."'";
 
-        $this->assertContains(
-            "invalid value 'not_a_valid_proxy_type' for 'proxy_type', must be one of ".$expected,
-            $invalid
-        );
+        $enumErrors = array_filter($invalid, fn ($msg) => str_contains($msg, 'invalid value'));
+        $this->assertEmpty($enumErrors, 'Unknown enum values should not produce invalid properties');
     }
 
     /**
@@ -237,5 +234,33 @@ class ProxyDetailsTest extends TestCase
 
         $this->assertNull($model->getProxyType());
         $this->assertFalse($model->isNullableSetToNull('proxy_type'));
+    }
+
+    /**
+     * Deserializing a JSON response with an unknown proxy_type should not throw.
+     * The unknown value should be preserved through deserialization and re-serialization.
+     *
+     * @throws \DateMalformedStringException
+     */
+    public function testDeserializationWithUnknownProxyType(): void
+    {
+        $json = json_encode([
+            'proxy_type' => 'corporate',
+            'last_seen_at' => 1700000000,
+            'provider' => 'example',
+        ]);
+
+        /** @var ProxyDetails $model */
+        $model = ObjectSerializer::deserialize(json_decode($json), ProxyDetails::class);
+
+        $this->assertEquals('corporate', $model->getProxyType());
+        $this->assertEquals(1700000000, $model->getLastSeenAt());
+        $this->assertEquals('example', $model->getProvider());
+        $this->assertTrue($model->valid());
+
+        // Re-serialization should preserve the unknown value
+        $reserialized = json_encode(ObjectSerializer::sanitizeForSerialization($model));
+        $decoded = json_decode($reserialized, true);
+        $this->assertEquals('corporate', $decoded['proxy_type']);
     }
 }

--- a/test/Model/SDKTest.php
+++ b/test/Model/SDKTest.php
@@ -61,14 +61,14 @@ class SDKTest extends TestCase
     }
 
     /**
-     * setPlatform should throw InvalidArgumentException for an invalid enum value.
+     * setPlatform should accept unknown enum values without throwing.
      */
-    public function testSetPlatformRejectsInvalidValue(): void
+    public function testSetPlatformAcceptsUnknownValue(): void
     {
         $model = new SDK();
 
-        $this->expectException(\InvalidArgumentException::class);
         $model->setPlatform('invalid');
+        $this->assertEquals('invalid', $model->getPlatform());
     }
 
     /**
@@ -168,21 +168,18 @@ class SDKTest extends TestCase
     }
 
     /**
-     * listInvalidProperties should report invalid enum values set via ArrayAccess bypass.
+     * listInvalidProperties should not report unknown enum values.
      */
-    public function testListInvalidPropertiesWithInvalidEnumValues(): void
+    public function testListInvalidPropertiesAcceptsUnknownEnumValues(): void
     {
         $model = new SDK(self::EXAMPLE);
 
         $model['platform'] = 'not_a_valid_platform';
 
         $invalid = $model->listInvalidProperties();
-        $expected = "'".implode("', '", self::PLATFORM_VALUES)."'";
 
-        $this->assertContains(
-            "invalid value 'not_a_valid_platform' for 'platform', must be one of ".$expected,
-            $invalid
-        );
+        $enumErrors = array_filter($invalid, fn ($msg) => str_contains($msg, 'invalid value'));
+        $this->assertEmpty($enumErrors, 'Unknown enum values should not produce invalid properties');
     }
 
     /**

--- a/test/Model/UnknownEnumDeserializationTest.php
+++ b/test/Model/UnknownEnumDeserializationTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Fingerprint\ServerSdk\Test\Model;
+
+use Fingerprint\ServerSdk\Model\BotInfo;
+use Fingerprint\ServerSdk\Model\Error;
+use Fingerprint\ServerSdk\Model\Event;
+use Fingerprint\ServerSdk\Model\EventRuleAction;
+use Fingerprint\ServerSdk\Model\Proximity;
+use Fingerprint\ServerSdk\Model\ProxyDetails;
+use Fingerprint\ServerSdk\Model\SDK;
+use Fingerprint\ServerSdk\ObjectSerializer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that all enum types accept values not yet defined in the SDK.
+ * This ensures the SDK does not break when the API introduces new enum values.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+class UnknownEnumDeserializationTest extends TestCase
+{
+    private const UNRECOGNIZED_VALUE = 'unrecognized_value_for_test';
+
+    // ── Standalone enums (referenced via openAPITypes) ──────────────
+
+    /**
+     * @throws \DateMalformedStringException
+     */
+    public function testEventWithUnknownIncrementalIdentificationStatus(): void
+    {
+        $json = json_encode([
+            'event_id' => 'evt_1',
+            'timestamp' => 1700000000,
+            'incremental_identification_status' => self::UNRECOGNIZED_VALUE,
+        ]);
+
+        /** @var Event $model */
+        $model = ObjectSerializer::deserialize(json_decode($json), Event::class);
+
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $model->getIncrementalIdentificationStatus());
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $this->reserialize($model)['incremental_identification_status']);
+    }
+
+    /**
+     * @throws \DateMalformedStringException
+     */
+    public function testEventWithUnknownBotResult(): void
+    {
+        $json = json_encode([
+            'event_id' => 'evt_1',
+            'timestamp' => 1700000000,
+            'bot' => self::UNRECOGNIZED_VALUE,
+        ]);
+
+        /** @var Event $model */
+        $model = ObjectSerializer::deserialize(json_decode($json), Event::class);
+
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $model->getBot());
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $this->reserialize($model)['bot']);
+    }
+
+    /**
+     * @throws \DateMalformedStringException
+     */
+    public function testEventWithUnknownProxyConfidence(): void
+    {
+        $json = json_encode([
+            'event_id' => 'evt_1',
+            'timestamp' => 1700000000,
+            'proxy_confidence' => self::UNRECOGNIZED_VALUE,
+        ]);
+
+        /** @var Event $model */
+        $model = ObjectSerializer::deserialize(json_decode($json), Event::class);
+
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $model->getProxyConfidence());
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $this->reserialize($model)['proxy_confidence']);
+    }
+
+    /**
+     * @throws \DateMalformedStringException
+     */
+    public function testEventWithUnknownTamperingConfidence(): void
+    {
+        $json = json_encode([
+            'event_id' => 'evt_1',
+            'timestamp' => 1700000000,
+            'tampering_confidence' => self::UNRECOGNIZED_VALUE,
+        ]);
+
+        /** @var Event $model */
+        $model = ObjectSerializer::deserialize(json_decode($json), Event::class);
+
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $model->getTamperingConfidence());
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $this->reserialize($model)['tampering_confidence']);
+    }
+
+    /**
+     * @throws \DateMalformedStringException
+     */
+    public function testEventWithUnknownVpnConfidence(): void
+    {
+        $json = json_encode([
+            'event_id' => 'evt_1',
+            'timestamp' => 1700000000,
+            'vpn_confidence' => self::UNRECOGNIZED_VALUE,
+        ]);
+
+        /** @var Event $model */
+        $model = ObjectSerializer::deserialize(json_decode($json), Event::class);
+
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $model->getVpnConfidence());
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $this->reserialize($model)['vpn_confidence']);
+    }
+
+    /**
+     * @throws \DateMalformedStringException
+     */
+    public function testEventWithUnknownRareDevicePercentileBucket(): void
+    {
+        $json = json_encode([
+            'event_id' => 'evt_1',
+            'timestamp' => 1700000000,
+            'rare_device_percentile_bucket' => self::UNRECOGNIZED_VALUE,
+        ]);
+
+        /** @var Event $model */
+        $model = ObjectSerializer::deserialize(json_decode($json), Event::class);
+
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $model->getRareDevicePercentileBucket());
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $this->reserialize($model)['rare_device_percentile_bucket']);
+    }
+
+    /**
+     * @throws \DateMalformedStringException
+     */
+    public function testEventRuleActionWithUnknownRuleActionType(): void
+    {
+        $json = json_encode([
+            'ruleset_id' => 'rs_1',
+            'rule_id' => 'r_1',
+            'rule_expression' => 'true',
+            'type' => self::UNRECOGNIZED_VALUE,
+        ]);
+
+        /** @var EventRuleAction $model */
+        $model = ObjectSerializer::deserialize(json_decode($json), EventRuleAction::class);
+
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $model->getType());
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $this->reserialize($model)['type']);
+    }
+
+    /**
+     * @throws \DateMalformedStringException
+     */
+    public function testErrorWithUnknownErrorCode(): void
+    {
+        $json = json_encode([
+            'code' => self::UNRECOGNIZED_VALUE,
+            'message' => 'Something went wrong',
+        ]);
+
+        /** @var Error $model */
+        $model = ObjectSerializer::deserialize(json_decode($json), Error::class);
+
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $model->getCode());
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $this->reserialize($model)['code']);
+    }
+
+    // ── Inline enums (string properties with allowable values) ──────
+
+    /**
+     * @throws \DateMalformedStringException
+     */
+    public function testProxyDetailsWithUnknownProxyType(): void
+    {
+        $json = json_encode([
+            'proxy_type' => self::UNRECOGNIZED_VALUE,
+            'last_seen_at' => 1700000000,
+            'provider' => 'example',
+        ]);
+
+        /** @var ProxyDetails $model */
+        $model = ObjectSerializer::deserialize(json_decode($json), ProxyDetails::class);
+
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $model->getProxyType());
+        $this->assertTrue($model->valid());
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $this->reserialize($model)['proxy_type']);
+    }
+
+    /**
+     * @throws \DateMalformedStringException
+     */
+    public function testBotInfoWithUnknownIdentity(): void
+    {
+        $json = json_encode([
+            'category' => 'other',
+            'provider' => 'example',
+            'name' => 'TestBot',
+            'identity' => self::UNRECOGNIZED_VALUE,
+            'confidence' => 'high',
+        ]);
+
+        /** @var BotInfo $model */
+        $model = ObjectSerializer::deserialize(json_decode($json), BotInfo::class);
+
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $model->getIdentity());
+        $this->assertTrue($model->valid());
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $this->reserialize($model)['identity']);
+    }
+
+    /**
+     * @throws \DateMalformedStringException
+     */
+    public function testBotInfoWithUnknownConfidence(): void
+    {
+        $json = json_encode([
+            'category' => 'other',
+            'provider' => 'example',
+            'name' => 'TestBot',
+            'identity' => 'verified',
+            'confidence' => self::UNRECOGNIZED_VALUE,
+        ]);
+
+        /** @var BotInfo $model */
+        $model = ObjectSerializer::deserialize(json_decode($json), BotInfo::class);
+
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $model->getConfidence());
+        $this->assertTrue($model->valid());
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $this->reserialize($model)['confidence']);
+    }
+
+    /**
+     * @throws \DateMalformedStringException
+     */
+    public function testSDKWithUnknownPlatform(): void
+    {
+        $json = json_encode([
+            'platform' => self::UNRECOGNIZED_VALUE,
+            'version' => '1.0.0',
+        ]);
+
+        /** @var SDK $model */
+        $model = ObjectSerializer::deserialize(json_decode($json), SDK::class);
+
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $model->getPlatform());
+        $this->assertTrue($model->valid());
+        $this->assertSame(self::UNRECOGNIZED_VALUE, $this->reserialize($model)['platform']);
+    }
+
+    /**
+     * @throws \DateMalformedStringException
+     */
+    public function testProximityWithUnknownPrecisionRadius(): void
+    {
+        $json = json_encode([
+            'id' => 'prox_1',
+            'precision_radius' => 999,
+            'confidence' => 0.95,
+        ]);
+
+        /** @var Proximity $model */
+        $model = ObjectSerializer::deserialize(json_decode($json), Proximity::class);
+
+        $this->assertSame(999, $model->getPrecisionRadius());
+        $this->assertTrue($model->valid());
+        $this->assertSame(999, $this->reserialize($model)['precision_radius']);
+    }
+
+    /**
+     * Helper: serialize a model to an associative array (simulating a JSON round-trip).
+     */
+    private function reserialize(object $model): array
+    {
+        return json_decode(
+            json_encode(ObjectSerializer::sanitizeForSerialization($model)),
+            true,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Remove strict enum validation from model setters and listing methods.
- Use `tryFrom()` instead of `from()` for standalone enum deserialization, falling back to raw string
- Add `|string` union types to standalone enum setter/getter type hints
- Remove `getAllowableEnumValues()` check during serialization (see ObjectSerializer class)

## Problem
The SDK throws `InvalidArgumentException` (inline enum) or `ValueError` (native enum) when the API returns an enum value not yet defined in the SDK. This means any new enum value added server-side breaks all SDK users who haven't updated yet.

## Solution
Accept unknown enum values **gracefully**. Known values still resolve to their enum types, unknown values pass through as raw strings. No breaking changes to the public API.
