### PR TITLE
INTER-2283: Update GitHub Actions

### DIFF
--- a/.github/workflows/coverage-diff.yml
+++ b/.github/workflows/coverage-diff.yml
@@ -6,18 +6,18 @@ jobs:
   coverage-diff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           clean: false
-      - uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
-          php-version: 8.2
+          php-version: 8.4
           coverage: none
           tools: composer:v2
           extensions: xdebug
       - name: Install Dependencies
         run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
-      - uses: KengoTODA/actions-setup-docker-compose@4677f0d86d41e623c9c6e11e1d910976da297bc0
+      - uses: KengoTODA/actions-setup-docker-compose@477353946803dd64eaa44008b865b6bfc88cab4e # v1.2.4
         with:
           version: '2.14.2'
       - name: "Create Empty env File for Docker"
@@ -34,25 +34,25 @@ jobs:
           echo "COVERAGE_PR=$COVERAGE_PR" >> $GITHUB_ENV
       - name: Upload coverage report markdown
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report-md
           path: cov/markdown/coverage_report.md
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           clean: false
 
-      - uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
-          php-version: 8.2
+          php-version: 8.4
           coverage: none
           tools: composer:v2
           extensions: xdebug
       - name: Install Dependencies
         run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
-      - uses: KengoTODA/actions-setup-docker-compose@4677f0d86d41e623c9c6e11e1d910976da297bc0
+      - uses: KengoTODA/actions-setup-docker-compose@477353946803dd64eaa44008b865b6bfc88cab4e # v1.2.4
         with:
           version: '2.14.2'
       - name: "Create Empty env File for Docker"
@@ -93,7 +93,7 @@ jobs:
           echo "COVERAGE_MESSAGE=$COVERAGE_MESSAGE" >> $GITHUB_ENV
 
       - name: Download coverage report markdown
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage-report-md
           path: cov/markdown/
@@ -108,7 +108,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Add comment with coverage report
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           message: "${{ env.combined_message }}"
       - name: Add coverage report to the job summary

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -10,16 +10,16 @@ jobs:
   coverage-report:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231
+      - uses: actions/checkout@v7
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
-          php-version: 8.2
+          php-version: 8.4
           coverage: none
           tools: composer:v2
           extensions: xdebug
       - name: Install Dependencies
         run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
-      - uses: KengoTODA/actions-setup-docker-compose@4677f0d86d41e623c9c6e11e1d910976da297bc0
+      - uses: KengoTODA/actions-setup-docker-compose@477353946803dd64eaa44008b865b6bfc88cab4e # v1.2.4
         with:
           version: '2.14.2'
       - name: "Create Empty env File for Docker"
@@ -29,13 +29,13 @@ jobs:
       - name: "Parse Coverage"
         run: "php ./generate_coverage_report.php"
       - name: Create Coverage Badges
-        uses: jaywcjlove/coverage-badges-cli@df58615045079f1c827de7867044bbab3ec22b43
+        uses: jaywcjlove/coverage-badges-cli@998665f7962b1a3935ba8c3e786171a99436e5d1 # v2.3.0
         with:
           source: cov/json/index.json
           output: cov/html/coverage.svg
           jsonPath: total.statements.pct
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@920cbb300dcd3f0568dbc42700c61e2fd9e6139c
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages
           folder: cov/html

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Read version from config.json
         id: version
         run: echo version=$(node -p "require('./package.json').version") >> $GITHUB_OUTPUT

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -24,11 +24,11 @@ jobs:
       matrix:
         php_version: [ "8.2", "8.3", "8.4" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup PHP
-        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: "${{ matrix.php_version }}"
           coverage: none

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,16 @@ jobs:
         php_version: [ "8.2", "8.3", "8.4" ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup PHP
-        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: "${{ matrix.php_version }}"
           coverage: xdebug
           tools: composer:v2
       - name: Install Dependencies
         run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
-      - uses: php-actions/phpunit@1789d1964b1bfda259b1cb42a72b65299c2cae35
+      - uses: php-actions/phpunit@1789d1964b1bfda259b1cb42a72b65299c2cae35 # v4.0.0
         env:
           XDEBUG_MODE: "coverage"
         with:


### PR DESCRIPTION
## Summary
- Update official actions to the latest major versions
  - `actions/checkout` v4 -> v7
  - `upload-artifact` v4 -> v7
  - `download-artifact` v4 -> v8
- Update 3rd party actions to latest commit SHAs
  - `shivammathur/setup-php` v2.31.1 -> v2.37.2 (new default values and features, doesn't affect us)
    - ⚠️ now it's installing PHP 8.4 instead of PHP 8.2
  - `KengoTODA/actions-setup-docker-compose` v1.2.2 -> v1.2.4 (nodejs runtime and dep bumps)
  - `marocchino/sticky-pull-request-comment` v3.0.5 (dep bumps)
  - `jaywcjlove/coverage-badges-cli` v2.3.0 (nodejs runtime and dep bumps)
  - `JamesIves/github-pages-deploy-action` v4.8.0 (nodejs runtime, dep bumps, new input)

## Test plan
- [x] All CI workflows pass
- [x] No deprecation warnings in action logs
  - There is a known deprecation warning caused by `fingerprintjs/dx-team-toolkit/.github/actions/changeset-release-notes@v1`. It's okay to ignore.