### PR TITLE
INTER-2285: Update webhook documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,28 @@ All URIs are relative to your region's base URL.
 | Europe      | https://eu.api.fpjs.io/v4 |
 | Asia        | https://ap.api.fpjs.io/v4 |
 
-## Webhook Signing
+## Webhooks
 
-This SDK provides utility method for verifying the HMAC signature of the incoming webhook request.
-You can use below code to verify signature:
+### Webhook types
+
+When handling [Webhooks](https://docs.fingerprint.com/docs/webhooks) coming from Fingerprint, you can cast the webhook payload as the built-in `Event` type using `ObjectSerializer::deserialize`:
+
+```php
+<?php
+
+use Fingerprint\ServerSdk\ObjectSerializer;
+use Fingerprint\ServerSdk\Model\Event;
+
+// $webhookData is the raw JSON string from the incoming webhook request body
+$event = ObjectSerializer::deserialize(
+    json_decode($webhookData),
+    Event::class
+);
+```
+
+### Webhook signature validation
+
+Fingerprint offers [Webhook signatures](https://docs.fingerprint.com/docs/webhooks#protecting-your-webhooks) to verify the authenticity of incoming webhook requests. This SDK provides a utility method for verification:
 
 ```php
 <?php
@@ -200,7 +218,7 @@ use Fingerprint\ServerSdk\Webhook\WebhookVerifier;
 // Your webhook signing secret.
 $webhookSecret = "secret";
 
-// Request data. In real life scenerio this will be the body of incoming request
+// Request data. In real life scenario this will be the body of incoming request
 $webhookData = "data";
 
 // Value of the "fpjs-event-signature" header.

--- a/docs/Webhook.md
+++ b/docs/Webhook.md
@@ -4,8 +4,7 @@
 
 > Fingerprint\ServerSdk\Webhook\WebhookVerifier::IsValidWebhookSignature(string $header, string $data, string $secret): bool
 
-Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of the webhook signing process, which is available only for enterprise customers.
-If you wish to enable it, please [contact our support](https://fingerprint.com/support).
+Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of the [webhook signing](https://docs.fingerprint.com/docs/webhooks#protecting-your-webhooks) process.
 
 ### Required Parameters
 

--- a/template/README.mustache
+++ b/template/README.mustache
@@ -197,10 +197,28 @@ All URIs are relative to your region's base URL.
 | Europe      | https://eu.api.fpjs.io/v4 |
 | Asia        | https://ap.api.fpjs.io/v4 |
 
-## Webhook Signing
+## Webhooks
 
-This SDK provides utility method for verifying the HMAC signature of the incoming webhook request.
-You can use below code to verify signature:
+### Webhook types
+
+When handling [Webhooks](https://docs.fingerprint.com/docs/webhooks) coming from Fingerprint, you can cast the webhook payload as the built-in `Event` type using `ObjectSerializer::deserialize`:
+
+```php
+<?php
+
+use Fingerprint\ServerSdk\ObjectSerializer;
+use Fingerprint\ServerSdk\Model\Event;
+
+// $webhookData is the raw JSON string from the incoming webhook request body
+$event = ObjectSerializer::deserialize(
+    json_decode($webhookData),
+    Event::class
+);
+```
+
+### Webhook signature validation
+
+Fingerprint offers [Webhook signatures](https://docs.fingerprint.com/docs/webhooks#protecting-your-webhooks) to verify the authenticity of incoming webhook requests. This SDK provides a utility method for verification:
 
 ```php
 <?php
@@ -210,7 +228,7 @@ use Fingerprint\ServerSdk\Webhook\WebhookVerifier;
 // Your webhook signing secret.
 $webhookSecret = "secret";
 
-// Request data. In real life scenerio this will be the body of incoming request
+// Request data. In real life scenario this will be the body of incoming request
 $webhookData = "data";
 
 // Value of the "fpjs-event-signature" header.

--- a/template/Webhook/Webhook.md.mustache
+++ b/template/Webhook/Webhook.md.mustache
@@ -4,8 +4,7 @@
 
 > {{invokerPackage}}\Webhook\WebhookVerifier::IsValidWebhookSignature(string $header, string $data, string $secret): bool
 
-Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of the webhook signing process, which is available only for enterprise customers.
-If you wish to enable it, please [contact our support]({{organizationUrl}}/support).
+Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of the [webhook signing](https://docs.fingerprint.com/docs/webhooks#protecting-your-webhooks) process.
 
 ### Required Parameters
 


### PR DESCRIPTION
## Summary
- Remove the "enterprise only" part from the webhook documentation. Webhook signing is now available to all plans.
- Add a "Webhook types" subsection showing how to deserialize webhook payloads into a typed `Event` object using the `ObjectSerializer::deserialize` helper.

## Test plan
- [X] `docs/Webhook.md` does not mention "enterprise only"
- [X] README has "Webhook types" and "Webhook signature validation" subsections
- [X] Generated files match templates after `generate.sh` (already covered by workflow)