### PR TITLE
INTER-2287: Add PHP 8.5 support

### DIFF
--- a/.changeset/add-php-85-support.md
+++ b/.changeset/add-php-85-support.md
@@ -1,0 +1,5 @@
+---
+"@fingerprint/php-sdk": minor
+---
+
+Added support for `PHP 8.5`.

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        php_version: [ "8.2", "8.3", "8.4" ]
+        php_version: [ "8.2", "8.3", "8.4", "8.5" ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php_version: [ "8.2", "8.3", "8.4" ]
+        php_version: [ "8.2", "8.3", "8.4", "8.5" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This library supports the following PHP implementations:
 - PHP 8.2
 - PHP 8.3
 - PHP 8.4
+- PHP 8.5
 
 We currently don't support external PHP Runtimes like:
 

--- a/template/README.mustache
+++ b/template/README.mustache
@@ -44,6 +44,7 @@ This library supports the following PHP implementations:
 - PHP 8.2
 - PHP 8.3
 - PHP 8.4
+- PHP 8.5
 
 We currently don't support external PHP Runtimes like:
 


### PR DESCRIPTION
# Summary

- Add `PHP 8.5` to the test and functional workflow matrices
- Add `PHP 8.5` to the README requirements section
- No code changes needed
  - `composer.json` already requires `^8.2` which covers `8.5` version

## Test plan
- [x] All tests pass on PHP 8.5 in CI