### PR TITLE
Switch Docker images from Debian to Alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - ./:/app
   php:
-    image: php:8.4-cli
+    image: php:8.4-cli-alpine
     volumes:
       - ./:/app
     working_dir: /app

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,11 +1,16 @@
-FROM php:8.4-cli
+FROM php:8.4-cli-alpine
 
 # Install dependencies and Xdebug
-RUN apt-get update && apt-get install -y \
-    libicu-dev \
+RUN apk add --no-cache \
+    icu-dev \
+    linux-headers \
+    autoconf \
+    g++ \
+    make \
     && docker-php-ext-install intl \
     && pecl install xdebug \
-    && docker-php-ext-enable xdebug
+    && docker-php-ext-enable xdebug \
+    && apk del autoconf g++ make
 
 # Configure Xdebug
 COPY xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,16 +1,17 @@
 FROM php:8.4-cli-alpine
 
-# Install dependencies and Xdebug
-RUN apk add --no-cache \
+# Install runtime dependencies
+RUN apk add --no-cache icu-libs
+
+# Install build dependencies
+RUN apk add --no-cache --virtual .build-deps \
+    $PHPIZE_DEPS \
     icu-dev \
     linux-headers \
-    autoconf \
-    g++ \
-    make \
     && docker-php-ext-install intl \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug \
-    && apk del autoconf g++ make
+    && apk del .build-deps
 
 # Configure Xdebug
 COPY xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini

--- a/scripts/functional.sh
+++ b/scripts/functional.sh
@@ -4,4 +4,4 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 require_cmd docker
 
-docker container run --env-file .env --rm -v "${PWD}:/app/" php:8.1-cli php /app/run_checks.php
+docker container run --env-file .env --rm -v "${PWD}:/app/" php:8.4-cli-alpine php /app/run_checks.php


### PR DESCRIPTION
## Summary

- Migrate Docker base images from `php:8.4-cli` to `php:8.4-cli-alpine` to reduce the number of potentially vulnerable packages on the base image
- Update `Dockerfile` to use `apk` instead of `apt-get`
- Fix `scripts/functional.sh` Docker image
