### PR TITLE
INTER-2353: Migrate from Docker Compose v1 to v2

### DIFF
--- a/.github/workflows/coverage-diff.yml
+++ b/.github/workflows/coverage-diff.yml
@@ -17,15 +17,12 @@ jobs:
           extensions: xdebug
       - name: Install Dependencies
         run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
-      - uses: KengoTODA/actions-setup-docker-compose@477353946803dd64eaa44008b865b6bfc88cab4e # v1.2.4
-        with:
-          version: '2.14.2'
       - name: "Create Empty env File for Docker"
         run: touch .env
       - name: Clear previous coverage data
         run: rm -f cov/xml/clover-pr.xml cov/xml/clover-base.xml cov/xml/clover.xml
       - name: PHPUnit for PR
-        run: docker-compose run phpunit
+        run: docker compose run phpunit
       - name: Create coverage report for PR
         id: pr_coverage
         run: |
@@ -52,13 +49,10 @@ jobs:
           extensions: xdebug
       - name: Install Dependencies
         run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
-      - uses: KengoTODA/actions-setup-docker-compose@477353946803dd64eaa44008b865b6bfc88cab4e # v1.2.4
-        with:
-          version: '2.14.2'
       - name: "Create Empty env File for Docker"
         run: touch .env
       - name: PHPUnit for Base
-        run: docker-compose run phpunit
+        run: docker compose run phpunit
       - name: Create coverage report for Base
         id: base_coverage
         run: |

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -19,13 +19,10 @@ jobs:
           extensions: xdebug
       - name: Install Dependencies
         run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
-      - uses: KengoTODA/actions-setup-docker-compose@477353946803dd64eaa44008b865b6bfc88cab4e # v1.2.4
-        with:
-          version: '2.14.2'
       - name: "Create Empty env File for Docker"
         run: touch .env
       - name: PHPUnit
-        run: docker-compose run --user "$(id -u):$(id -g)" phpunit
+        run: docker compose run --user "$(id -u):$(id -g)" phpunit
       - name: "Parse Coverage"
         run: "php ./generate_coverage_report.php"
       - name: Create Coverage Badges

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   composer:
     image: composer:2.7

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,6 @@
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
-require_cmd docker-compose
+require_cmd docker
 
-docker-compose run composer install --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
+docker compose run composer install --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,6 +2,6 @@
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
-require_cmd docker-compose
+require_cmd docker
 
-docker-compose run phpunit
+docker compose run phpunit


### PR DESCRIPTION
## Summary
- Remove obsolete `version` field from `docker-compose.yml`
  - New Docker Compose ignores it and ⚠️  emits a deprecation warning
- Replace `docker-compose` with `docker compose` in scripts and CI workflows
- Remove `KengoTODA/actions-setup-docker-compose` 3rd party action from workflows

## Why

The `docker-compose` (v1) binary has been officially EOL since July 2023. All Docker Desktop has shipped Compose V2 (since the same date I think). GitHub Actions official runners come with `docker compose` pre-installed. We don't need the `KengoTODA/actions-setup-docker-compose` action.
