### PR TITLE
INTER-2354: Align php-cs-fixer version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     env_file:
       - .env
   lint:
-    image: ghcr.io/php-cs-fixer/php-cs-fixer:3.64-php8.3
+    image: ghcr.io/php-cs-fixer/php-cs-fixer:3.95-php8.4
     volumes:
       - .:/code
       - ./.php-cs-fixer.php:/code/.php-cs-fixer.php

--- a/scripts/php-cs-fixer.sh
+++ b/scripts/php-cs-fixer.sh
@@ -2,7 +2,7 @@
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
-PHP_CS_FIXER_IMAGE_VERSION="3.95-php8.1"
+PHP_CS_FIXER_IMAGE_VERSION="3.95-php8.4"
 
 require_cmd docker
 


### PR DESCRIPTION
## Summary
- Align `php-cs-fixer` Docker image version between files.
- All now use `ghcr.io/php-cs-fixer/php-cs-fixer:3.95-php8.4`

## Problem
Two different php-cs-fixer versions were in use:
- `docker-compose.yml`: `3.64-php8.3`
- `scripts/php-cs-fixer.sh`: `3.95-php8.1`

This meant linting with `docker compose run lint` and `./scripts/php-cs-fixer.sh` could produce different results.