### PR TITLE
INTER-2355: Remove stale deprecation suppression

### DIFF
--- a/sealed_results_example.php
+++ b/sealed_results_example.php
@@ -12,11 +12,6 @@ $dotenv->safeLoad();
 $sealed_result = base64_decode($_ENV['BASE64_SEALED_RESULT'] ?? getenv('BASE64_SEALED_RESULT') ?? '');
 $sealed_key = base64_decode($_ENV['BASE64_KEY'] ?? getenv('BASE64_KEY') ?? '');
 
-// Temporarily suppress a million deprecated ArrayAccess return type warnings for readability
-// Our SDK generator does not yet support PHP's new attributes system
-// https://github.com/swagger-api/swagger-codegen/issues/11820
-error_reporting(error_reporting() & ~E_DEPRECATED);
-
 try {
     $data = Sealed::unsealEventResponse($sealed_result, [new DecryptionKey($sealed_key, DecryptionAlgorithm::AES_256_GCM)]);
 
@@ -26,9 +21,6 @@ try {
 
     exit(1);
 }
-
-// Enable the deprecated ArrayAccess return type warning again if needed
-error_reporting(error_reporting() | E_DEPRECATED);
 
 fwrite(STDOUT, "Checks passed\n");
 


### PR DESCRIPTION
## Summary

- Remove `error_reporting` suppression of `E_DEPRECATED` from `sealed_results_example.php`
- Remove stale comment referencing `swagger-codegen` (⚠️ ⚠️ we use `openapi-generator`)

## Why

The suppression was added to silence `ArrayAccess` return type deprecation warnings in older PHP versions. This is no longer needed because:
- Generated model code already includes `#[\ReturnTypeWillChange]` attributes (with openapi-generator migration)
- Methods declare proper `mixed` return types
- Our minimum PHP version is 8.2