### PR TITLE
INTER-2356: Improve release scripts

### DIFF
--- a/changeset-publish.sh
+++ b/changeset-publish.sh
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
+
+set -euo pipefail
+
 bash ./scripts/generate.sh && pnpm exec changeset publish

--- a/changeset-version.sh
+++ b/changeset-version.sh
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
+
+set -euo pipefail
+
 pnpm exec changeset version && bash ./scripts/generate.sh

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     "require": {
         "php": "^8.2",
         "ext-curl": "*",
-        "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^7.3",
         "guzzlehttp/psr7": "^1.7 || ^2.0",
@@ -51,6 +50,7 @@
     },
     "replace": {
         "symfony/polyfill-php80": "*",
-        "symfony/polyfill-php81": "*"
+        "symfony/polyfill-php81": "*",
+        "symfony/polyfill-php82": "*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "761b438e606d2971a5ad00fa82fbfb15",
+    "content-hash": "3ced318af2a0e55ab9620b819045bbff",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -5055,7 +5055,6 @@
     "platform": {
         "php": "^8.2",
         "ext-curl": "*",
-        "ext-json": "*",
         "ext-mbstring": "*",
         "ext-zlib": "*",
         "ext-openssl": "*"

--- a/template/composer.mustache
+++ b/template/composer.mustache
@@ -33,7 +33,6 @@
     "require": {
         "php": "^8.2",
         "ext-curl": "*",
-        "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^7.3",
         "guzzlehttp/psr7": "^1.7 || ^2.0",
@@ -53,6 +52,7 @@
     },
     "replace": {
         "symfony/polyfill-php80": "*",
-        "symfony/polyfill-php81": "*"
+        "symfony/polyfill-php81": "*",
+        "symfony/polyfill-php82": "*"
     }
 }


### PR DESCRIPTION
## Summary
- Add `set -euo pipefail` to changeset scripts.
- Remove `ext-json` requirement from `composer.json`.
- Add `symfony/polyfill-php82` to the `replace` section.

## Why
- We add `set -euo pipefail` to changeset scripts so failures are caught.
- `ext-json` has always been bundled and non-removable since PHP 8.0. Requiring it is unnecessary.
- Since our minimum is PHP 8.2, `polyfill-php82` is equally unnecessary and should be replaced to avoid pulling.
