### PR TITLE
INTER-2360: Modernize Sealed module

### DIFF
--- a/.changeset/refactor-sealed-module.md
+++ b/.changeset/refactor-sealed-module.md
@@ -1,0 +1,5 @@
+---
+"@fingerprint/php-sdk": patch
+---
+
+Improved type safety and PHP 8.2+ compatibility in the Sealed Result module.

--- a/src/Sealed/DecryptionKey.php
+++ b/src/Sealed/DecryptionKey.php
@@ -2,16 +2,12 @@
 
 namespace Fingerprint\ServerSdk\Sealed;
 
-class DecryptionKey
+readonly class DecryptionKey
 {
-    private string $key;
-    private DecryptionAlgorithm $algorithm;
-
-    public function __construct(string $key, DecryptionAlgorithm $algorithm)
-    {
-        $this->key = $key;
-        $this->algorithm = $algorithm;
-    }
+    public function __construct(
+        private string $key,
+        private DecryptionAlgorithm $algorithm,
+    ) {}
 
     public function getKey(): string
     {

--- a/src/Sealed/Sealed.php
+++ b/src/Sealed/Sealed.php
@@ -9,7 +9,7 @@ class Sealed
 {
     private const NONCE_LENGTH = 12;
     private const AUTH_TAG_LENGTH = 16;
-    private static string $SEAL_HEADER = "\x9E\x85\xDC\xED";
+    private const SEAL_HEADER = "\x9E\x85\xDC\xED";
 
     /**
      * @param DecryptionKey[] $keys
@@ -48,7 +48,7 @@ class Sealed
      */
     public static function unseal(string $sealed, array $keys): string
     {
-        if (!str_starts_with($sealed, self::$SEAL_HEADER)) {
+        if (!str_starts_with($sealed, self::SEAL_HEADER)) {
             throw new InvalidSealedDataHeaderException();
         }
 
@@ -58,7 +58,7 @@ class Sealed
             switch ($key->getAlgorithm()) {
                 case DecryptionAlgorithm::AES_256_GCM:
                     try {
-                        $data = substr($sealed, strlen(self::$SEAL_HEADER));
+                        $data = substr($sealed, strlen(self::SEAL_HEADER));
 
                         return self::decryptAes256Gcm($data, $key->getKey());
                     } catch (\Exception $exception) {
@@ -100,13 +100,11 @@ class Sealed
     }
 
     /**
-     * @param bool|string $data
-     *
      * @throws DecompressionException
      */
-    private static function decompress(mixed $data): string
+    private static function decompress(string $data): string
     {
-        if (false === $data || 0 === strlen($data)) {
+        if (0 === strlen($data)) {
             throw new DecompressionException();
         }
         $inflated = @gzinflate($data); // Ignore warnings, because we check the decompressed data's validity and throw error if necessary

--- a/src/Sealed/UnsealAggregateException.php
+++ b/src/Sealed/UnsealAggregateException.php
@@ -5,16 +5,16 @@ namespace Fingerprint\ServerSdk\Sealed;
 class UnsealAggregateException extends \Exception
 {
     /**
-     * @var \Exception[]
+     * @var UnsealException[]
      */
-    private array $exceptions;
+    private array $exceptions = [];
 
     public function __construct()
     {
         parent::__construct('Failed to unseal with all decryption keys');
     }
 
-    public function addException(\Exception $exception): void
+    public function addException(UnsealException $exception): void
     {
         $this->exceptions[] = $exception;
     }

--- a/src/Sealed/UnsealException.php
+++ b/src/Sealed/UnsealException.php
@@ -4,9 +4,9 @@ namespace Fingerprint\ServerSdk\Sealed;
 
 class UnsealException extends \Exception
 {
-    public string $decryptionKeyDescription;
+    public readonly string $decryptionKeyDescription;
 
-    public function __construct($message, $cause, DecryptionKey $decryptionKey)
+    public function __construct(string $message, \Throwable $cause, DecryptionKey $decryptionKey)
     {
         parent::__construct($message, 0, $cause);
         $key = $decryptionKey->getKey();

--- a/template/Sealed/DecryptionKey.mustache
+++ b/template/Sealed/DecryptionKey.mustache
@@ -2,18 +2,12 @@
 
 namespace {{invokerPackage}}\Sealed;
 
-use {{invokerPackage}}\Sealed\DecryptionAlgorithm;
-
-class DecryptionKey
+readonly class DecryptionKey
 {
-    private string $key;
-    private DecryptionAlgorithm $algorithm;
-
-    public function __construct(string $key, DecryptionAlgorithm $algorithm)
-    {
-        $this->key = $key;
-        $this->algorithm = $algorithm;
-    }
+    public function __construct(
+        private string $key,
+        private DecryptionAlgorithm $algorithm,
+    ) {}
 
     public function getKey(): string
     {

--- a/template/Sealed/Sealed.mustache
+++ b/template/Sealed/Sealed.mustache
@@ -9,7 +9,7 @@ class Sealed
 {
     private const NONCE_LENGTH = 12;
     private const AUTH_TAG_LENGTH = 16;
-    private static string $SEAL_HEADER = "\x9E\x85\xDC\xED";
+    private const SEAL_HEADER = "\x9E\x85\xDC\xED";
 
     /**
      * @param DecryptionKey[] $keys
@@ -48,7 +48,7 @@ class Sealed
      */
     public static function unseal(string $sealed, array $keys): string
     {
-        if (!str_starts_with($sealed, self::$SEAL_HEADER)) {
+        if (!str_starts_with($sealed, self::SEAL_HEADER)) {
             throw new InvalidSealedDataHeaderException();
         }
 
@@ -58,7 +58,7 @@ class Sealed
             switch ($key->getAlgorithm()) {
                 case DecryptionAlgorithm::AES_256_GCM:
                     try {
-                        $data = substr($sealed, strlen(self::$SEAL_HEADER));
+                        $data = substr($sealed, strlen(self::SEAL_HEADER));
 
                         return self::decryptAes256Gcm($data, $key->getKey());
                     } catch (\Exception $exception) {
@@ -100,13 +100,11 @@ class Sealed
     }
 
     /**
-     * @param bool|string $data
-     *
      * @throws DecompressionException
      */
-    private static function decompress(mixed $data): string
+    private static function decompress(string $data): string
     {
-        if (false === $data || 0 === strlen($data)) {
+        if (0 === strlen($data)) {
             throw new DecompressionException();
         }
         $inflated = @gzinflate($data); // Ignore warnings, because we check the decompressed data's validity and throw error if necessary

--- a/template/Sealed/UnsealAggregateException.mustache
+++ b/template/Sealed/UnsealAggregateException.mustache
@@ -2,21 +2,19 @@
 
 namespace {{invokerPackage}}\Sealed;
 
-use Exception;
-
 class UnsealAggregateException extends \Exception
 {
     /**
-     * @var \Exception[]
+     * @var UnsealException[]
      */
-    private array $exceptions;
+    private array $exceptions = [];
 
     public function __construct()
     {
         parent::__construct('Failed to unseal with all decryption keys');
     }
 
-    public function addException(Exception $exception): void
+    public function addException(UnsealException $exception): void
     {
         $this->exceptions[] = $exception;
     }

--- a/template/Sealed/UnsealException.mustache
+++ b/template/Sealed/UnsealException.mustache
@@ -4,9 +4,9 @@ namespace {{invokerPackage}}\Sealed;
 
 class UnsealException extends \Exception
 {
-    public string $decryptionKeyDescription;
+    public readonly string $decryptionKeyDescription;
 
-    public function __construct($message, $cause, DecryptionKey $decryptionKey)
+    public function __construct(string $message, \Throwable $cause, DecryptionKey $decryptionKey)
     {
         parent::__construct($message, 0, $cause);
         $key = $decryptionKey->getKey();

--- a/test/SealedTest.php
+++ b/test/SealedTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\TestCase;
  * @internal
  */
 #[CoversClass(Sealed::class)]
+#[CoversClass(UnsealAggregateException::class)]
 class SealedTest extends TestCase
 {
     public const VALID_KEY = 'p2PA7MGy5tx56cnyJaFZMr96BCFwZeHjZV2EqMvTq53=';
@@ -159,6 +160,12 @@ class SealedTest extends TestCase
             $sealedResult,
             [$this->keys[0]]
         );
+    }
+
+    public function testUnsealAggregateExceptionReturnsEmptyArrayWhenNoExceptionsAdded()
+    {
+        $exception = new UnsealAggregateException();
+        $this->assertSame([], $exception->getExceptions());
     }
 
     public function testUnsealEventResponseWithInvalidNonce()


### PR DESCRIPTION
## Summary
- Convert `Sealed::$SEAL_HEADER` from a static property to a class constant
- Use constructor property promotion and `readonly class` for `DecryptionKey`
- Add missing type declarations to `UnsealException` constructor
- Mark `UnsealException::$decryptionKeyDescription` as `readonly`
- Fix `UnsealAggregateException::$exceptions` uninitialized property
  - ⚠️ ⚠️  was crashing if `getExceptions()` (internally, we don't expect it's called) was called before `addException()`
- Narrow `addException()` parameter from `\Exception` to `UnsealException`
- Fix `decompress()` parameter type from `mixed` to `string`
- Add test verifying `UnsealAggregateException::getExceptions()` returns an empty array when no exceptions are added

> [!WARNING]
> **Note on public API changes**
>
> Some public signatures were tightened:
>
> - added type declarations to `UnsealException` constructor
> - narrowed `addException()` parameter from `\Exception` to `UnsealException`
> - marked `DecryptionKey` as `readonly class`.
>
> These classes are internal for sealed result decryption. Consumers only interact with `Sealed::unsealEventResponse()` and the `DecryptionKey` constructor. **The likelihood of anyone subclassing or directly constructing the exception classes is very low.** Because of that, we are using `patch` instead of `major`.


## PHP version compatibility

All features used are available in our minimum supported version (PHP 8.2):
- **Constructor property promotion** -> PHP 8.0+
- **`readonly` properties** -> PHP 8.1+
- **`readonly class`** -> PHP 8.2+