### PR TITLE
INTER-2361: Rename IsValidWebhookSignature to camelCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ $webhookData = "data";
 // Value of the "fpjs-event-signature" header.
 $webhookHeader = "v1=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db";
 
-$isValidWebhookSign = WebhookVerifier::IsValidWebhookSignature($webhookHeader, $webhookData, $webhookSecret);
+$isValidWebhookSign = WebhookVerifier::isValidWebhookSignature($webhookHeader, $webhookData, $webhookSecret);
 
 if(!$isValidWebhookSign) {
     fwrite(STDERR, sprintf("Webhook signature verification failed\n"));

--- a/docs/Webhook.md
+++ b/docs/Webhook.md
@@ -1,8 +1,8 @@
 # Webhook
 
-## **IsValidWebhookSignature**
+## **isValidWebhookSignature**
 
-> Fingerprint\ServerSdk\Webhook\WebhookVerifier::IsValidWebhookSignature(string $header, string $data, string $secret): bool
+> Fingerprint\ServerSdk\Webhook\WebhookVerifier::isValidWebhookSignature(string $header, string $data, string $secret): bool
 
 Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of the [webhook signing](https://docs.fingerprint.com/docs/webhooks#protecting-your-webhooks) process.
 

--- a/run_checks.php
+++ b/run_checks.php
@@ -135,7 +135,7 @@ $eventPromise->then(function ($promiseResult) use ($eventId) {
 $webhookSecret = 'secret';
 $webhookData = 'data';
 $webhookHeader = 'v1=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db';
-$isValidWebhookSign = WebhookVerifier::IsValidWebhookSignature($webhookHeader, $webhookData, $webhookSecret);
+$isValidWebhookSign = WebhookVerifier::isValidWebhookSignature($webhookHeader, $webhookData, $webhookSecret);
 if ($isValidWebhookSign) {
     fwrite(STDOUT, "\n\nVerified webhook signature\n");
 } else {

--- a/src/Webhook/WebhookVerifier.php
+++ b/src/Webhook/WebhookVerifier.php
@@ -14,7 +14,7 @@ final class WebhookVerifier
      * @param string $data   raw webhook request body
      * @param string $secret webhook signing secret
      */
-    public static function IsValidWebhookSignature(string $header, string $data, string $secret): bool
+    public static function isValidWebhookSignature(string $header, string $data, string $secret): bool
     {
         $signatures = explode(',', $header);
         foreach ($signatures as $signature) {

--- a/template/README.mustache
+++ b/template/README.mustache
@@ -235,7 +235,7 @@ $webhookData = "data";
 // Value of the "fpjs-event-signature" header.
 $webhookHeader = "v1=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db";
 
-$isValidWebhookSign = WebhookVerifier::IsValidWebhookSignature($webhookHeader, $webhookData, $webhookSecret);
+$isValidWebhookSign = WebhookVerifier::isValidWebhookSignature($webhookHeader, $webhookData, $webhookSecret);
 
 if(!$isValidWebhookSign) {
     fwrite(STDERR, sprintf("Webhook signature verification failed\n"));

--- a/template/Webhook/Webhook.md.mustache
+++ b/template/Webhook/Webhook.md.mustache
@@ -1,8 +1,8 @@
 # Webhook
 
-## **IsValidWebhookSignature**
+## **isValidWebhookSignature**
 
-> {{invokerPackage}}\Webhook\WebhookVerifier::IsValidWebhookSignature(string $header, string $data, string $secret): bool
+> {{invokerPackage}}\Webhook\WebhookVerifier::isValidWebhookSignature(string $header, string $data, string $secret): bool
 
 Verifies the HMAC signature extracted from the "fpjs-event-signature" header of the incoming request. This is a part of the [webhook signing](https://docs.fingerprint.com/docs/webhooks#protecting-your-webhooks) process.
 

--- a/template/Webhook/WebhookVerifier.mustache
+++ b/template/Webhook/WebhookVerifier.mustache
@@ -14,7 +14,7 @@ final class WebhookVerifier
      * @param string $data   raw webhook request body
      * @param string $secret webhook signing secret
      */
-    public static function IsValidWebhookSignature(string $header, string $data, string $secret): bool
+    public static function isValidWebhookSignature(string $header, string $data, string $secret): bool
     {
         $signatures = explode(',', $header);
         foreach ($signatures as $signature) {

--- a/test/WebhookVerifierTest.php
+++ b/test/WebhookVerifierTest.php
@@ -24,7 +24,7 @@ class WebhookVerifierTest extends TestCase
     {
         /** @noinspection SpellCheckingInspection */
         $validHeader = 'v1=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db';
-        $result = WebhookVerifier::IsValidWebhookSignature($validHeader, $this->data, $this->secret);
+        $result = WebhookVerifier::isValidWebhookSignature($validHeader, $this->data, $this->secret);
         $this->assertTrue($result, 'With valid signature');
     }
 
@@ -33,7 +33,7 @@ class WebhookVerifierTest extends TestCase
      */
     public function testWithInvalidHeader(): void
     {
-        $result = WebhookVerifier::IsValidWebhookSignature('v2=invalid', $this->data, $this->secret);
+        $result = WebhookVerifier::isValidWebhookSignature('v2=invalid', $this->data, $this->secret);
         $this->assertFalse($result, 'With invalid header');
     }
 
@@ -42,7 +42,7 @@ class WebhookVerifierTest extends TestCase
      */
     public function testWithHeaderWithoutVersion(): void
     {
-        $result = WebhookVerifier::IsValidWebhookSignature('invalid', $this->data, $this->secret);
+        $result = WebhookVerifier::isValidWebhookSignature('invalid', $this->data, $this->secret);
         $this->assertFalse($result, 'With header without version');
     }
 
@@ -51,7 +51,7 @@ class WebhookVerifierTest extends TestCase
      */
     public function testWithEmptyHeader(): void
     {
-        $result = WebhookVerifier::IsValidWebhookSignature('', $this->data, $this->secret);
+        $result = WebhookVerifier::isValidWebhookSignature('', $this->data, $this->secret);
         $this->assertFalse($result, 'With empty header');
     }
 
@@ -62,7 +62,7 @@ class WebhookVerifierTest extends TestCase
     {
         /** @noinspection SpellCheckingInspection */
         $validHeader = 'v1=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db';
-        $result = WebhookVerifier::IsValidWebhookSignature($validHeader, $this->data, '');
+        $result = WebhookVerifier::isValidWebhookSignature($validHeader, $this->data, '');
         $this->assertFalse($result, 'With empty secret');
     }
 
@@ -73,7 +73,7 @@ class WebhookVerifierTest extends TestCase
     {
         /** @noinspection SpellCheckingInspection */
         $validHeader = 'v1=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db';
-        $result = WebhookVerifier::IsValidWebhookSignature($validHeader, '', $this->secret);
+        $result = WebhookVerifier::isValidWebhookSignature($validHeader, '', $this->secret);
         $this->assertFalse($result, 'With empty data');
     }
 }


### PR DESCRIPTION
## Summary
- Rename `WebhookVerifier::IsValidWebhookSignature()` to `isValidWebhookSignature()`
  - PSR-1 valid
- Update all references in other files

## Why not a breaking change ❓

PHP function/method names are [case-insensitive](https://www.php.net/manual/en/functions.user-defined.php) for all PHP versions. Existing consumer code calling `WebhookVerifier::IsValidWebhookSignature()` will continue to work without any changes.