### PR TITLE
INTER-2363: Remove deprecated composer flag

### DIFF
--- a/.github/workflows/coverage-diff.yml
+++ b/.github/workflows/coverage-diff.yml
@@ -16,7 +16,7 @@ jobs:
           tools: composer:v2
           extensions: xdebug
       - name: Install Dependencies
-        run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
+        run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --prefer-dist
       - uses: KengoTODA/actions-setup-docker-compose@477353946803dd64eaa44008b865b6bfc88cab4e # v1.2.4
         with:
           version: '2.14.2'
@@ -51,7 +51,7 @@ jobs:
           tools: composer:v2
           extensions: xdebug
       - name: Install Dependencies
-        run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
+        run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --prefer-dist
       - uses: KengoTODA/actions-setup-docker-compose@477353946803dd64eaa44008b865b6bfc88cab4e # v1.2.4
         with:
           version: '2.14.2'

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -18,7 +18,7 @@ jobs:
           tools: composer:v2
           extensions: xdebug
       - name: Install Dependencies
-        run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
+        run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --prefer-dist
       - uses: KengoTODA/actions-setup-docker-compose@477353946803dd64eaa44008b865b6bfc88cab4e # v1.2.4
         with:
           version: '2.14.2'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,7 +12,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v7
-      - name: Read version from config.json
+      - name: Read version from package.json
         id: version
         run: echo version=$(node -p "require('./package.json').version") >> $GITHUB_OUTPUT
   e2e-tests:

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -34,7 +34,7 @@ jobs:
           coverage: none
           tools: composer:v2
       - name: Install Dependencies
-        run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
+        run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --prefer-dist
       - name: "Try to get data using SDK"
         run: "php ./run_checks.php"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       language: php
       language-version: '8.3'
       prepare-command: |
-        composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
+        composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --prefer-dist
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       RUNNER_APP_PRIVATE_KEY: ${{ secrets.RUNNER_APP_PRIVATE_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: xdebug
           tools: composer:v2
       - name: Install Dependencies
-        run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
+        run: composer install -q --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --prefer-dist
       - uses: php-actions/phpunit@1789d1964b1bfda259b1cb42a72b65299c2cae35 # v4.0.0
         env:
           XDEBUG_MODE: "coverage"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,4 +4,4 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 require_cmd docker-compose
 
-docker-compose run composer install --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --no-suggest --prefer-dist
+docker-compose run composer install --profile --ignore-platform-reqs --no-interaction --no-ansi --no-scripts --prefer-dist


### PR DESCRIPTION
## Summary
- Remove deprecated `--no-suggest` flag from `composer install`
- Fix misleading step name in `e2e-tests.yml`

## Why
- `--no-suggest` was deprecated in Composer 2.6 (suggestions are now hidden by default). It produces a deprecation warning when running with Composer 2.6+.
- The `e2e-tests.yml` one step says `Read version from config.json` but the command reads from `package.json`.
