### PR TITLE
INTER-2365: Wrap async rejection exceptions in ApiException before handling

### DIFF
--- a/.changeset/fix-async-error-handler.md
+++ b/.changeset/fix-async-error-handler.md
@@ -1,0 +1,5 @@
+---
+"@fingerprint/php-sdk": patch
+---
+
+Fixed async error handling throwing TypeError instead of ApiException on failed requests.

--- a/src/Api/FingerprintApi.php
+++ b/src/Api/FingerprintApi.php
@@ -232,6 +232,28 @@ class FingerprintApi
                     return [null, $response];
                 },
                 function ($e) {
+                    if ($e instanceof RequestException) {
+                        $e = new ApiException(
+                            "[{$e->getCode()}] {$e->getMessage()}",
+                            (int) $e->getCode(),
+                            $e->getResponse(),
+                            $e
+                        );
+                    } elseif ($e instanceof ConnectException) {
+                        $e = new ApiException(
+                            "[{$e->getCode()}] {$e->getMessage()}",
+                            (int) $e->getCode(),
+                            null,
+                            $e
+                        );
+                    } elseif (!$e instanceof ApiException) {
+                        $e = new ApiException(
+                            $e->getMessage(),
+                            (int) $e->getCode(),
+                            null,
+                            $e
+                        );
+                    }
                     $this->handleDeleteVisitorDataError($e);
                 }
             );
@@ -425,6 +447,28 @@ class FingerprintApi
                     ];
                 },
                 function ($e) {
+                    if ($e instanceof RequestException) {
+                        $e = new ApiException(
+                            "[{$e->getCode()}] {$e->getMessage()}",
+                            (int) $e->getCode(),
+                            $e->getResponse(),
+                            $e
+                        );
+                    } elseif ($e instanceof ConnectException) {
+                        $e = new ApiException(
+                            "[{$e->getCode()}] {$e->getMessage()}",
+                            (int) $e->getCode(),
+                            null,
+                            $e
+                        );
+                    } elseif (!$e instanceof ApiException) {
+                        $e = new ApiException(
+                            $e->getMessage(),
+                            (int) $e->getCode(),
+                            null,
+                            $e
+                        );
+                    }
                     $this->handleGetEventError($e);
                 }
             );
@@ -825,6 +869,28 @@ class FingerprintApi
                     ];
                 },
                 function ($e) {
+                    if ($e instanceof RequestException) {
+                        $e = new ApiException(
+                            "[{$e->getCode()}] {$e->getMessage()}",
+                            (int) $e->getCode(),
+                            $e->getResponse(),
+                            $e
+                        );
+                    } elseif ($e instanceof ConnectException) {
+                        $e = new ApiException(
+                            "[{$e->getCode()}] {$e->getMessage()}",
+                            (int) $e->getCode(),
+                            null,
+                            $e
+                        );
+                    } elseif (!$e instanceof ApiException) {
+                        $e = new ApiException(
+                            $e->getMessage(),
+                            (int) $e->getCode(),
+                            null,
+                            $e
+                        );
+                    }
                     $this->handleSearchEventsError($e);
                 }
             );
@@ -1525,6 +1591,28 @@ class FingerprintApi
                     return [null, $response];
                 },
                 function ($e) {
+                    if ($e instanceof RequestException) {
+                        $e = new ApiException(
+                            "[{$e->getCode()}] {$e->getMessage()}",
+                            (int) $e->getCode(),
+                            $e->getResponse(),
+                            $e
+                        );
+                    } elseif ($e instanceof ConnectException) {
+                        $e = new ApiException(
+                            "[{$e->getCode()}] {$e->getMessage()}",
+                            (int) $e->getCode(),
+                            null,
+                            $e
+                        );
+                    } elseif (!$e instanceof ApiException) {
+                        $e = new ApiException(
+                            $e->getMessage(),
+                            (int) $e->getCode(),
+                            null,
+                            $e
+                        );
+                    }
                     $this->handleUpdateEventError($e);
                 }
             );

--- a/template/api.mustache
+++ b/template/api.mustache
@@ -274,6 +274,28 @@ use {{invokerPackage}}\ObjectSerializer;
                     {{/returnType}}
                 },
                 function ($e) {
+                    if ($e instanceof RequestException) {
+                        $e = new ApiException(
+                            "[{$e->getCode()}] {$e->getMessage()}",
+                            (int) $e->getCode(),
+                            $e->getResponse(),
+                            $e
+                        );
+                    } elseif ($e instanceof ConnectException) {
+                        $e = new ApiException(
+                            "[{$e->getCode()}] {$e->getMessage()}",
+                            (int) $e->getCode(),
+                            null,
+                            $e
+                        );
+                    } elseif (!($e instanceof ApiException)) {
+                        $e = new ApiException(
+                            $e->getMessage(),
+                            (int) $e->getCode(),
+                            null,
+                            $e
+                        );
+                    }
                     $this->handle{{#lambda.pascalcase}}{{operationId}}{{/lambda.pascalcase}}Error($e);
                 }
             );

--- a/test/Api/FingerprintApiAsyncErrorTest.php
+++ b/test/Api/FingerprintApiAsyncErrorTest.php
@@ -10,8 +10,10 @@ use Fingerprint\ServerSdk\Model\ErrorResponse;
 use Fingerprint\ServerSdk\Model\EventUpdate;
 use Fingerprint\ServerSdk\Test\MockHelper;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -99,5 +101,57 @@ class FingerprintApiAsyncErrorTest extends TestCase
 
             throw $e;
         }
+    }
+
+    public function testGetEventAsyncConnectException(): void
+    {
+        $this->mockHandler->append(new ConnectException(
+            'Connection refused',
+            new Request('GET', '/events/test')
+        ));
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches('/Connection refused/');
+
+        $this->api->getEventAsync('test')->wait();
+    }
+
+    public function testSearchEventsAsyncConnectException(): void
+    {
+        $this->mockHandler->append(new ConnectException(
+            'DNS resolution failed',
+            new Request('GET', '/events/search')
+        ));
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches('/DNS resolution failed/');
+
+        $this->api->searchEventsAsync()->wait();
+    }
+
+    public function testDeleteVisitorDataAsyncConnectException(): void
+    {
+        $this->mockHandler->append(new ConnectException(
+            'Connection timed out',
+            new Request('DELETE', '/visitors/test')
+        ));
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches('/Connection timed out/');
+
+        $this->api->deleteVisitorDataAsync('test')->wait();
+    }
+
+    public function testUpdateEventAsyncConnectException(): void
+    {
+        $this->mockHandler->append(new ConnectException(
+            'Network unreachable',
+            new Request('PATCH', '/events/test')
+        ));
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches('/Network unreachable/');
+
+        $this->api->updateEventAsync('test', new EventUpdate())->wait();
     }
 }

--- a/test/Api/FingerprintApiAsyncErrorTest.php
+++ b/test/Api/FingerprintApiAsyncErrorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Fingerprint\ServerSdk\Test\Api;
+
+use Fingerprint\ServerSdk\Api\FingerprintApi;
+use Fingerprint\ServerSdk\ApiException;
+use Fingerprint\ServerSdk\Configuration;
+use Fingerprint\ServerSdk\Model\ErrorCode;
+use Fingerprint\ServerSdk\Model\ErrorResponse;
+use Fingerprint\ServerSdk\Model\EventUpdate;
+use Fingerprint\ServerSdk\Test\MockHelper;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that async operations correctly wrap Guzzle exceptions in ApiException.
+ *
+ * @internal
+ */
+#[CoversClass(FingerprintApi::class)]
+class FingerprintApiAsyncErrorTest extends TestCase
+{
+    private FingerprintApi $api;
+    private MockHandler $mockHandler;
+
+    public function setUp(): void
+    {
+        $this->mockHandler = new MockHandler();
+        $client = new Client(['handler' => HandlerStack::create($this->mockHandler)]);
+        $this->api = new FingerprintApi(new Configuration('test-api-key'), $client);
+    }
+
+    public function testGetEventAsyncError(): void
+    {
+        $this->mockHandler->append(MockHelper::getMockResponse(MockHelper::OPERATION_ERROR_404_EVENT_NOT_FOUND));
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionCode(404);
+
+        try {
+            $this->api->getEventAsync('invalid')->wait();
+        } catch (ApiException $e) {
+            $this->assertInstanceOf(ErrorResponse::class, $e->getErrorDetails());
+            $this->assertSame(ErrorCode::EVENT_NOT_FOUND, $e->getErrorDetails()->getError()->getCode());
+
+            throw $e;
+        }
+    }
+
+    public function testSearchEventsAsyncError(): void
+    {
+        $this->mockHandler->append(MockHelper::getMockResponse(MockHelper::OPERATION_ERROR_403_WRONG_REGION));
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionCode(403);
+
+        try {
+            $this->api->searchEventsAsync()->wait();
+        } catch (ApiException $e) {
+            $this->assertInstanceOf(ErrorResponse::class, $e->getErrorDetails());
+            $this->assertSame(ErrorCode::WRONG_REGION, $e->getErrorDetails()->getError()->getCode());
+
+            throw $e;
+        }
+    }
+
+    public function testDeleteVisitorDataAsyncError(): void
+    {
+        $this->mockHandler->append(MockHelper::getMockResponse(MockHelper::OPERATION_ERROR_400_VISITOR_ID_INVALID));
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionCode(400);
+
+        try {
+            $this->api->deleteVisitorDataAsync('invalid')->wait();
+        } catch (ApiException $e) {
+            $this->assertInstanceOf(ErrorResponse::class, $e->getErrorDetails());
+            $this->assertSame(ErrorCode::REQUEST_CANNOT_BE_PARSED, $e->getErrorDetails()->getError()->getCode());
+
+            throw $e;
+        }
+    }
+
+    public function testUpdateEventAsyncError(): void
+    {
+        $this->mockHandler->append(MockHelper::getMockResponse(MockHelper::OPERATION_ERROR_404_EVENT_NOT_FOUND));
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionCode(404);
+
+        try {
+            $this->api->updateEventAsync('invalid', new EventUpdate())->wait();
+        } catch (ApiException $e) {
+            $this->assertInstanceOf(ErrorResponse::class, $e->getErrorDetails());
+            $this->assertSame(ErrorCode::EVENT_NOT_FOUND, $e->getErrorDetails()->getError()->getCode());
+
+            throw $e;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `TypeError` in async error handling by converting `RequestException` and `ConnectException` to `ApiException` in the async rejection callback
- Matches the existing conversion logic in the synchronous path

## Problem
The async methods (`*Async`, `*AsyncWithHttpInfo`) passed the raw Guzzle exception to the error handler, which is typed `ApiException $e`. Since Guzzle's promise rejection provides `ClientException`/`RequestException`, this caused a `TypeError` at runtime whenever an async request failed with an HTTP error.

The synchronous path correctly wraps these exceptions:
```php
} catch (RequestException $e) {
    throw new ApiException("[{$e->getCode()}] {$e->getMessage()}", ...);
}
```

But the async path passed them directly:
```php
function ($e) {
    $this->handleDeleteVisitorDataError($e); // TypeError: expected ApiException
}
```

## Solution
Added the same `RequestException` -> `ApiException` and `ConnectException` -> `ApiException` conversion in the async rejection callback.
